### PR TITLE
feat: To reverted master: Add new linkdrop standard fixes & trial account offboarding

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,7 +13,7 @@
         "build": "yarn run bundle && yarn run sentry",
         "bundle": "cross-env NODE_ENV=production node ci/runBundler.js",
         "check": "tsc --noEmit",
-        "dev": "yarn && cross-env NEAR_WALLET_ENV=mainnet yarn start",
+        "dev": "yarn && cross-env NEAR_WALLET_ENV=testnet yarn start",
         "sentry": "node ci/sentry-send-release.js",
         "test": "jest",
         "lint": "eslint --ext .js --ext .jsx .",

--- a/packages/frontend/src/components/accounts/CreateAccount.js
+++ b/packages/frontend/src/components/accounts/CreateAccount.js
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import CONFIG from '../../config';
 import { Mixpanel } from '../../mixpanel/index';
 import {
-    checkNearDropBalance,
+    checkLinkdropInfo,
     checkNewAccount,
     redirectTo,
     refreshAccount
@@ -110,8 +110,8 @@ class CreateAccount extends Component {
     state = {
         loader: false,
         accountId: '',
-        invalidNearDrop: null,
-        fundingAmount: null,
+        invalidLinkdrop: null,
+        linkdropKeyInfo: null,
         termsAccepted: false,
         whereToBuy: false
     }
@@ -120,7 +120,7 @@ class CreateAccount extends Component {
         const { fundingContract, fundingKey } = this.props;
 
         if (fundingContract && fundingKey) {
-            this.handleCheckNearDropBalance();
+            this.handleCheckLinkdropInfo();
         }
     }
 
@@ -128,14 +128,14 @@ class CreateAccount extends Component {
         this.props.clearLocalAlert();
     }
 
-    handleCheckNearDropBalance = async () => {
-        const { fundingContract, fundingKey, checkNearDropBalance } = this.props;
+    handleCheckLinkdropInfo = async () => {
+        const { fundingContract, fundingKey, checkLinkdropInfo } = this.props;
         await Mixpanel.withTracking('CA Check near drop balance',
             async () => {
-                const fundingAmount = await checkNearDropBalance(fundingContract, fundingKey);
-                this.setState({ fundingAmount });
+                const linkdropKeyInfo = await checkLinkdropInfo(fundingContract, fundingKey);
+                this.setState({ linkdropKeyInfo });
             },
-            () => this.setState({ invalidNearDrop: true })
+            () => this.setState({ invalidLinkdrop: true })
         );
     }
 
@@ -148,7 +148,7 @@ class CreateAccount extends Component {
     }
 
     handleCreateAccount = async () => {
-        const { accountId, fundingAmount } = this.state;
+        const { accountId, linkdropKeyInfo } = this.state;
         const {
             fundingContract, fundingKey,
             fundingAccountId,
@@ -158,7 +158,7 @@ class CreateAccount extends Component {
 
         let queryString = '';
         if (fundingAccountId || fundingContract) {
-            const fundingOptions = fundingAccountId ? { fundingAccountId } : { fundingContract, fundingKey, fundingAmount };
+            const fundingOptions = fundingAccountId ? { fundingAccountId } : { fundingContract, fundingKey, fundingAmount: linkdropKeyInfo.yoctoNEAR };
             queryString = `?fundingOptions=${encodeURIComponent(JSON.stringify(fundingOptions))}`;
         }
         Mixpanel.track('CA Click create account button');
@@ -166,13 +166,7 @@ class CreateAccount extends Component {
     }
 
     render() {
-        const {
-            loader,
-            accountId,
-            invalidNearDrop,
-            termsAccepted,
-            whereToBuy
-        } = this.state;
+        const { loader, accountId, invalidLinkdrop, termsAccepted, whereToBuy } = this.state;
 
         const {
             localAlert,
@@ -242,7 +236,7 @@ class CreateAccount extends Component {
             );
         }
 
-        if (!invalidNearDrop) {
+        if (!invalidLinkdrop) {
             return (
                 <StyledContainer className='small-centered border'>
                     <form onSubmit={(e) => {
@@ -315,7 +309,7 @@ const mapDispatchToProps = {
     checkNewAccount,
     clearLocalAlert,
     refreshAccount,
-    checkNearDropBalance,
+    checkLinkdropInfo,
     redirectTo
 };
 

--- a/packages/frontend/src/components/accounts/LinkdropLanding.js
+++ b/packages/frontend/src/components/accounts/LinkdropLanding.js
@@ -1,22 +1,19 @@
-import { parse } from 'query-string';
 import React, { Component } from 'react';
 import { Translate } from 'react-localize-redux';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
 import { Mixpanel } from '../../mixpanel/index';
-import { checkNearDropBalance, claimLinkdropToAccount, redirectTo, handleRefreshUrl } from '../../redux/actions/account';
+import { checkLinkdropInfo, claimLinkdropToAccount, redirectTo, handleRefreshUrl } from '../../redux/actions/account';
 import { clearLocalAlert } from '../../redux/actions/status';
 import { selectAccountSlice } from '../../redux/slices/account';
 import { actions as linkdropActions } from '../../redux/slices/linkdrop';
 import { selectActionsPending, selectStatusMainLoader } from '../../redux/slices/status';
 import { isUrlNotJavascriptProtocol } from '../../utils/helper-api';
-import AccountDropdown from '../common/AccountDropdown';
-import Balance from '../common/balance/Balance';
-import FormButton from '../common/FormButton';
 import Container from '../common/styled/Container.css';
 import BrokenLinkIcon from '../svg/BrokenLinkIcon';
-import NearGiftIcons from '../svg/NearGiftIcons';
+import NearDropLanding from './linkdrops/NearDropLanding';
+import TrialDropLanding from './linkdrops/TrialDropLanding';
 
 const { setLinkdropAmount } = linkdropActions;
 
@@ -72,114 +69,109 @@ const StyledContainer = styled(Container)`
 
 class LinkdropLanding extends Component {
     state = {
-        balance: null,
-        invalidNearDrop: null
-    }
+        dropType: null,
+        keyInfo: null,
+        invalidNearDrop: null,
+    };
 
     componentDidMount() {
         const { fundingContract, fundingKey, handleRefreshUrl } = this.props;
         if (fundingContract && fundingKey) {
-            this.handleCheckNearDropBalance();
+            this.handleCheckLinkdropInfo();
             handleRefreshUrl();
         }
     }
 
-    handleCheckNearDropBalance = async () => {
-        const { fundingContract, fundingKey, checkNearDropBalance } = this.props;
-        await Mixpanel.withTracking('CA Check near drop balance',
-            async () => {
-                const balance = await checkNearDropBalance(fundingContract, fundingKey);
+  handleCheckLinkdropInfo = async () => {
+      const { fundingContract, fundingKey, checkLinkdropInfo } = this.props;
+      await Mixpanel.withTracking(
+          'CA Check near drop balance',
+          async () => {
+              const keyInfo = await checkLinkdropInfo(fundingContract, fundingKey);
 
-                this.setState({ balance });
-            },
-            () => this.setState({ invalidNearDrop: true })
-        );
-    }
+              // If there is trial data and exit is set to false, then the linkdrop should be invalid
+              if (keyInfo?.trial_data?.exit === false) {
+                  this.setState({ invalidNearDrop: true });
+              } else {
+                  this.setState({ keyInfo });
+              }
+          },
+          () => this.setState({ invalidNearDrop: true }),
+      );
+  };
 
-    handleClaimNearDrop = async () => {
-        const { fundingContract, fundingKey, redirectTo, claimLinkdropToAccount, accountId, url, setLinkdropAmount } = this.props;
-        await claimLinkdropToAccount(fundingContract, fundingKey);
-        if (url?.redirectUrl && isUrlNotJavascriptProtocol(url?.redirectUrl)) {
-            window.location = `${url.redirectUrl}?accountId=${accountId}`;
-        } else {
-            setLinkdropAmount(this.state.balance);
-            redirectTo('/');
-        }
-    }
+  handleClaimNearDrop = async () => {
+      const {
+          fundingContract,
+          fundingKey,
+          redirectTo,
+          claimLinkdropToAccount,
+          accountId,
+          url,
+          setLinkdropAmount,
+      } = this.props;
+      await claimLinkdropToAccount(fundingContract, fundingKey);
+      if (url?.redirectUrl && isUrlNotJavascriptProtocol(url?.redirectUrl)) {
+          window.location = `${url.redirectUrl}?accountId=${accountId}`;
+      } else {
+          setLinkdropAmount(this.state.keyInfo.yoctoNEAR);
+          redirectTo('/');
+      }
+  };
 
-    render() {
-        const { fundingContract, fundingKey, accountId, mainLoader, history, claimingDrop } = this.props;
-        const { balance, invalidNearDrop } = this.state;
-        const fundingAmount = balance;
+  render() {
+      const { fundingContract, fundingKey, accountId, mainLoader, history, claimingDrop } =
+      this.props;
+      const { keyInfo, invalidNearDrop } = this.state;
+      const fundingAmount = keyInfo?.yoctoNEAR || '0';
+      const isTrialDrop = keyInfo?.trial_data?.exit || false;
 
-        if (!invalidNearDrop) {
-            const params = parse(history.location.search);
-            const redirectUrl = params.redirectUrl ? `&redirectUrl=${encodeURIComponent(params.redirectUrl)}` : '';
+      if (!invalidNearDrop) {
+          if (isTrialDrop) {
+              return (
+                  <TrialDropLanding
+                      fundingContract={fundingContract}
+                      fundingKey={fundingKey}
+                      claimingDrop={claimingDrop}
+                      history={history}
+                  />
+              );
+          }
 
-            return (
-                <StyledContainer className='xs-centered'>
-                    <NearGiftIcons/>
-                    <h3><Translate id='linkdropLanding.title'/></h3>
-                    <div className='near-balance'>
-                        <Balance
-                            data-test-id="linkdropBalanceAmount"
-                            amount={balance}
-                        />
-                    </div>
-                    <div className='desc'>
-                        <Translate id='linkdropLanding.desc'/>
-                    </div>
-                    {accountId ? (
-                        <AccountDropdown
-                            disabled={claimingDrop}
-                            data-test-id="linkdropAccountDropdown"
-                        />
-                    ) : null}
-                    {accountId ? (
-                        <FormButton
-                            onClick={this.handleClaimNearDrop}
-                            sending={claimingDrop}
-                            disabled={mainLoader}
-                            sendingString='linkdropLanding.claiming'
-                            data-test-id="linkdropClaimToExistingAccount"
-                        >
-                            <Translate id='linkdropLanding.ctaAccount'/>
-                        </FormButton>
-                    ) : (
-                        <FormButton
-                            linkTo={`/recover-account?fundingOptions=${encodeURIComponent(JSON.stringify({ fundingContract, fundingKey, fundingAmount }))}${redirectUrl}`}
-                            data-test-id="linkdropLoginAndClaim"
-                        >
-                            <Translate id='linkdropLanding.ctaLogin'/>
-                        </FormButton>
-                    )}
-                    <div className='or'><Translate id='linkdropLanding.or'/></div>
-                    <FormButton
-                        data-test-id="linkdropCreateAccountToClaim"
-                        color="gray-blue"
-                        disabled={claimingDrop}
-                        linkTo={`/create/${fundingContract}/${fundingKey}`}
-                    >
-                        <Translate id='linkdropLanding.ctaNew'/>
-                    </FormButton>
-                </StyledContainer>
-            );
-        } else {
-            return (
-                <StyledContainer className='small-centered invalid-link'>
-                    <BrokenLinkIcon/>
-                    <h1><Translate id='createAccount.invalidLinkDrop.title'/></h1>
-                    <h2><Translate id='createAccount.invalidLinkDrop.one'/></h2>
-                    <h2><Translate id='createAccount.invalidLinkDrop.two'/></h2>
-                </StyledContainer>
-            );
-        }
-    }
+          return (
+              <NearDropLanding
+                  fundingContract={fundingContract}
+                  fundingKey={fundingKey}
+                  accountId={accountId}
+                  mainLoader={mainLoader}
+                  history={history}
+                  claimingDrop={claimingDrop}
+                  fundingAmount={fundingAmount}
+                  handleClaimNearDrop={this.handleClaimNearDrop}
+              />
+          );
+      } else {
+          return (
+              <StyledContainer className='small-centered invalid-link'>
+                  <BrokenLinkIcon />
+                  <h1>
+                      <Translate id='createAccount.invalidLinkDrop.title' />
+                  </h1>
+                  <h2>
+                      <Translate id='createAccount.invalidLinkDrop.one' />
+                  </h2>
+                  <h2>
+                      <Translate id='createAccount.invalidLinkDrop.two' />
+                  </h2>
+              </StyledContainer>
+          );
+      }
+  }
 }
 
 const mapDispatchToProps = {
     clearLocalAlert,
-    checkNearDropBalance,
+    checkLinkdropInfo,
     claimLinkdropToAccount,
     redirectTo,
     handleRefreshUrl,

--- a/packages/frontend/src/components/accounts/SetupSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/SetupSeedPhrase.js
@@ -60,9 +60,12 @@ class SetupSeedPhrase extends Component {
         const recoveryKeyPair = KeyPair.fromString(secretKey);
         const wordId = Math.floor(Math.random() * 12);
 
+        const fundingOptions = parseFundingOptions(location.search);
+        const isTrial = fundingOptions?.trialDrop || false;
+
         const isNewAccount = await checkIsNew(accountId);
 
-        if (!isNewAccount) {
+        if (!isNewAccount && !isTrial) {
             fetchRecoveryMethods({ accountId });
         }
 
@@ -135,7 +138,10 @@ class SetupSeedPhrase extends Component {
         } = this.props;
         const { recoveryKeyPair, recaptchaToken } = this.state;
 
-        if (!this.state.isNewAccount) {
+        const fundingOptions = parseFundingOptions(location.search);
+        const isTrial = fundingOptions?.trialDrop || false;
+
+        if (!this.state.isNewAccount && !isTrial) {
             debugLog('handleSetupSeedPhrase()/existing account');
 
             await Mixpanel.withTracking('SR-SP Setup for existing account',
@@ -143,8 +149,6 @@ class SetupSeedPhrase extends Component {
             );
             return;
         }
-
-        const fundingOptions = parseFundingOptions(location.search);
 
         await Mixpanel.withTracking('SR-SP Setup for new account',
             async () => {

--- a/packages/frontend/src/components/accounts/linkdrops/NearDropLanding.js
+++ b/packages/frontend/src/components/accounts/linkdrops/NearDropLanding.js
@@ -1,0 +1,129 @@
+import { parse } from 'query-string';
+import React from 'react';
+import { Translate } from 'react-localize-redux';
+import styled from 'styled-components';
+
+import AccountDropdown from '../../common/AccountDropdown';
+import Balance from '../../common/balance/Balance';
+import FormButton from '../../common/FormButton';
+import Container from '../../common/styled/Container.css';
+import NearGiftIcons from '../../svg/NearGiftIcons';
+
+const StyledContainer = styled(Container)`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+
+    .near-balance {
+        color: #0072CE;
+        font-weight: 600;
+        border: 1px solid #D6EDFF;
+        border-radius: 4px;
+        padding: 6px 15px;
+        background-color: #F0F9FF;
+        margin: 30px 0;
+    }
+
+    .desc {
+        color: #72727A;
+        margin-bottom: 40px;
+    }
+
+    h3 {
+        margin-top: 40px;
+    }
+
+    .or {
+        color: #A2A2A8;
+        margin: 20px 0 -6px 0;
+    }
+
+    button {
+        width: 100% !important;
+    }
+
+    .account-dropdown-container {
+        width: 100%;
+    }
+
+    &.invalid-link {
+        svg {
+            display: block;
+            margin: 0 auto;
+        }
+
+        h2 {
+            margin-top: 20px;
+        }
+    }
+`;
+
+const NearDropLanding = ({
+    fundingContract,
+    fundingKey,
+    accountId,
+    mainLoader,
+    history,
+    claimingDrop,
+    fundingAmount,
+    handleClaimNearDrop
+}) => {
+    const params = parse(history.location.search);
+    const redirectUrl = params.redirectUrl
+        ? `&redirectUrl=${encodeURIComponent(params.redirectUrl)}`
+        : '';
+
+    return (
+        <StyledContainer className='xs-centered'>
+            <NearGiftIcons />
+            <h3>
+                <Translate id='linkdropLanding.title' />
+            </h3>
+            <div className='near-balance'>
+                <Balance data-test-id="linkdropBalanceAmount" amount={fundingAmount} />
+            </div>
+            <div className='desc'>
+                <Translate id='linkdropLanding.desc' />
+            </div>
+
+            {accountId ? (
+                <AccountDropdown disabled={claimingDrop} data-test-id="linkdropAccountDropdown" />
+            ) : null}
+
+            {accountId ? (
+                <FormButton
+                    onClick={handleClaimNearDrop}
+                    sending={claimingDrop}
+                    disabled={mainLoader}
+                    sendingString='linkdropLanding.claiming'
+                    data-test-id="linkdropClaimToExistingAccount"
+                >
+                    <Translate id='linkdropLanding.ctaAccount' />
+                </FormButton>
+            ) : (
+                <FormButton
+                    linkTo={`/recover-account?fundingOptions=${encodeURIComponent(
+                        JSON.stringify({ fundingContract, fundingKey, fundingAmount }),
+                    )}${redirectUrl}`}
+                    data-test-id="linkdropLoginAndClaim"
+                >
+                    <Translate id='linkdropLanding.ctaLogin' />
+                </FormButton>
+            )}
+            <div className='or'>
+                <Translate id='linkdropLanding.or' />
+            </div>
+            <FormButton
+                data-test-id="linkdropCreateAccountToClaim"
+                color="gray-blue"
+                disabled={claimingDrop}
+                linkTo={`/create/${fundingContract}/${fundingKey}`}
+            >
+                <Translate id='linkdropLanding.ctaNew' />
+            </FormButton>
+        </StyledContainer>
+    );
+};
+
+export default NearDropLanding;

--- a/packages/frontend/src/components/accounts/linkdrops/TrialDropLanding.js
+++ b/packages/frontend/src/components/accounts/linkdrops/TrialDropLanding.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import FormButton from '../../common/FormButton';
+import Container from '../../common/styled/Container.css';
+import NearGiftIcons from '../../svg/NearGiftIcons';
+
+const StyledContainer = styled(Container)`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+
+    .desc {
+        color: #72727A;
+        margin-bottom: 40px;
+    }
+
+    h3 {
+        margin-top: 40px;
+    }
+
+    button {
+        width: 100% !important;
+    }
+`;
+
+const TrialDropLanding = ({
+    fundingContract,
+    fundingKey,
+    claimingDrop,
+    history
+}) => {
+    const handleSecureAccount = async () => {
+        let queryString = `?fundingOptions=${encodeURIComponent(JSON.stringify({ fundingContract, fundingKey, fundingAmount: '0', trialDrop: true }))}`;
+        history.push(`/set-recovery/${fundingContract}${queryString}`);
+    };
+
+    return (
+        <StyledContainer className='xs-centered'>
+            <NearGiftIcons />
+            <h3>
+            Secure Your Trial Account
+            </h3>
+            <div className='desc'>
+            We hope you enjoyed your trial. Add a seedphrase to secure your account!
+            </div>
+
+            <FormButton
+                data-test-id="linkdropCreateAccountToClaim"
+                color="gray-blue"
+                disabled={claimingDrop}
+                onClick={handleSecureAccount}
+            >
+            Secure Account
+            </FormButton>
+
+        </StyledContainer>
+    );
+};
+
+export default TrialDropLanding;

--- a/packages/frontend/src/redux/actions/account.js
+++ b/packages/frontend/src/redux/actions/account.js
@@ -247,7 +247,7 @@ export const {
     getLedgerPublicKey,
     setupRecoveryMessage,
     deleteRecoveryMethod,
-    checkNearDropBalance,
+    checkLinkdropInfo,
     claimLinkdropToAccount,
     checkIsNew,
     checkNewAccount,
@@ -334,8 +334,8 @@ export const {
         wallet.deleteRecoveryMethod.bind(wallet),
         () => showAlert()
     ],
-    CHECK_NEAR_DROP_BALANCE: [
-        wallet.checkNearDropBalance.bind(wallet),
+    CHECK_LINKDROP_INFO: [
+        wallet.checkLinkdropInfo.bind(wallet),
         () => ({})
     ],
     CLAIM_LINKDROP_TO_ACCOUNT: [
@@ -455,6 +455,7 @@ export const handleCreateAccountWithSeedPhrase = (accountId, recoveryKeyPair, fu
     try {
         await dispatch(createAccountWithSeedPhrase({ accountId, recoveryKeyPair, fundingOptions, recaptchaToken })).unwrap();
     } catch (error) {
+        console.log('error in handle create account with seedphrase: ', error);
         if (await wallet.accountExists(accountId)) {
             // Requests sometimes fail after creating the NEAR account for another reason (transport error?)
             // If that happened, we allow the user can add the NEAR account to the wallet by entering the seed phrase

--- a/packages/frontend/src/translations/locales/en/translation.json
+++ b/packages/frontend/src/translations/locales/en/translation.json
@@ -708,6 +708,7 @@
         "ctaLogin": "Log In and Claim",
         "ctaNew": "Claim with New Account",
         "desc": "You may claim your NEAR drop with an existing account (must be logged in), or create a new account to receive it as an initial deposit.",
+        "loadingText": "Fetching Linkdrop Info",
         "modal": {
             "desc": "Your NEAR drop has been automatically deposited to your account.",
             "title": "Your NEAR drop has been claimed"


### PR DESCRIPTION
# Copied from previous PR

## Changes description

- Layed the foundational work for different linkdrop types and rendering the linkdrop landing page accordingly.
- Introduced Trial Account Offboarding flow as a new type of linkdrop (more info found [here](https://docs.keypom.xyz/docs/next/TrialAccounts/offboarding))
- New linkdrop standard calls for different interfaces and methods. This has been (mostly) addressed in this PR
- Small bugfixes

## Demo

Trial Account flow is as follows:
1. The linkdrop landing page now looks as follows (this is *only* for trial accounts):
<img width="389" alt="image" src="https://user-images.githubusercontent.com/57506486/232339490-b6d55666-3d7c-438d-8a37-8ba5e03a0f29.png">
2. When the button is clicked, they go through the regular linkdrop claiming flow (except they don't choose an account ID):

- Choose recovery method

- Verify recovery method

- Create Account

A full demo:
https://drive.google.com/file/d/1hD1oFvO_RG5-PvzWJUvj-B96rniWY2zO/view?usp=share_link