### PR TITLE
change token namings

### DIFF
--- a/packages/e2e-tests/fungibleToken/fungibleToken.spec.js
+++ b/packages/e2e-tests/fungibleToken/fungibleToken.spec.js
@@ -1,0 +1,84 @@
+// @ts-check
+const { test, expect } = require("../playwrightWithFixtures");
+const { HomePage } = require("../register/models/Home");
+const { SwapPage } = require("../swap/models/Swap");
+const { SendMoneyPage } = require("../transfer-tokens/models/SendMoney");
+const E2eTestAccount = require("../utils/E2eTestAccount");
+const { describe, beforeAll, afterAll } = test;
+
+describe("Rename FT symbol", () => {
+  /**
+   * @type {E2eTestAccount}
+   */
+  let account;
+  beforeAll(async ({ bankAccount }) => {
+    account = bankAccount.spawnRandomSubAccountInstance();
+    await account.create();
+  });
+
+  afterAll(async () => {
+    await account.delete();
+  });
+
+  test("Bridged USDT and Bridged USDC is renamed properly", async ({
+    page,
+  }) => {
+    const homePage = new HomePage(page);
+    await homePage.loginAndNavigate(account.accountId, account.seedPhrase);
+    const swapPage = new SwapPage(page);
+    await swapPage.navigate();
+    await page.click("data-test-id=swapPageOutputTokenSelector");
+    const tokensName = [
+      {
+        addr: "usdt.fakes.testnet",
+        symbol: "Bridged USDT",
+      },
+      {
+        addr: "usdtt.fakes.testnet",
+        symbol: "Native USDT",
+      },
+      {
+        addr: "usdc.fakes.testnet",
+        symbol: "Bridged USDC",
+      },
+    ];
+    for (let i = 0; i < tokensName.length; i++) {
+      await expect(
+        page.locator(
+          `[data-test-id="token-selection-${tokensName[i].addr}"] .title`
+        )
+      ).toHaveText(tokensName[i].symbol);
+    }
+  });
+
+  test("Show warning when Bridged token is selected in send page", async ({
+    page,
+  }) => {
+    const homePage = new HomePage(page);
+    await homePage.loginAndNavigate(account.accountId, account.seedPhrase);
+    const swapPage = new SwapPage(page);
+    await swapPage.navigate();
+    await swapPage.fillForm({
+      inId: "NEAR",
+      inAmount: "0.5",
+      outId: "usdt.fakes.testnet",
+    });
+    await swapPage.clickOnPreviewButton();
+    await swapPage.confirmSwap();
+    await swapPage.waitResultMessageElement();
+    await swapPage.clickOnContinueAfterSwapButton();
+
+    const sendMoneyPage = new SendMoneyPage(page);
+    await expect(async () => {
+      await page.reload();
+      await sendMoneyPage.navigate();
+      await page.waitForTimeout(5000);
+      await page.click(`data-test-id=sendMoneyPageSelectTokenButton`);
+      await page.click(`data-test-id=token-selection-usdt.fakes.testnet`, {
+        timeout: 5 * 1000,
+      });
+      await sendMoneyPage.selectAsset("usdt.fakes.testnet");
+      expect(page.locator("data-test-id=bridge-token-warning")).toBeVisible();
+    }).toPass();
+  });
+});

--- a/packages/frontend/src/components/common/FormButton.js
+++ b/packages/frontend/src/components/common/FormButton.js
@@ -520,7 +520,7 @@ const FormButton = ({
             linkTo && (linkTo.toLowerCase().startsWith('http') ? window.open(linkTo, '_blank') : history.push(linkTo));
             trackingId && Mixpanel.track(trackingId);
         }}
-        tabIndex='3'
+        tabIndex={3}
         data-test-id={testId}
         style={style}
     >

--- a/packages/frontend/src/components/common/balance/FiatBalance.tsx
+++ b/packages/frontend/src/components/common/balance/FiatBalance.tsx
@@ -11,7 +11,7 @@ type FiatBalanceProps = {
     showSignUSD?: boolean,
     nearTokenFiatValueUSD?: number,
     isNear?: boolean,
-    decimals: number,
+    decimals?: number,
     totalAmount?: string
 }
 

--- a/packages/frontend/src/components/send/components/views/EnterAmount.js
+++ b/packages/frontend/src/components/send/components/views/EnterAmount.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import Balance from '../../../common/balance/Balance';
 import FormButton from '../../../common/FormButton';
+import Notification from '../../../common/Notification';
 import AmountInput from '../AmountInput';
 import BalanceDetails from '../BalanceDetails';
 import SelectTokenButton from '../SelectTokenButton';
@@ -34,6 +35,10 @@ const StyledContainer = styled.form`
         .select-token-btn {
             margin: 55px 0 5px 0;
         }
+
+        .warning-message {
+            margin-top: 15px;
+        }
     }
 `;
 
@@ -51,6 +56,7 @@ const EnterAmount = ({
     error,
     isMobile
 }) => {
+    const isBridgedToken = selectedToken?.onChainFTMetadata?.isBridged;
 
     return (
         <StyledContainer 
@@ -91,12 +97,19 @@ const EnterAmount = ({
                 availableToSend={availableToSend}
                 selectedToken={selectedToken}
             />
+            {isBridgedToken && (
+                <div className='warning-message' data-test-id='bridge-token-warning'>
+                    <Notification type='warning'>
+                        <Translate id='sendV2.enterAmount.bridgedTokenWarning' />
+                    </Notification>
+                </div>
+            )}
             <div className='buttons-bottom-buttons'>
                 {/* TODO: Add error state */}
                 <FormButton
                     type='submit'
                     disabled={!continueAllowed}
-                    data-test-id="sendMoneyPageSubmitAmountButton"
+                    data-test-id='sendMoneyPageSubmitAmountButton'
                 >
                     <Translate id='button.continue'/>
                 </FormButton>

--- a/packages/frontend/src/redux/slices/swap/index.js
+++ b/packages/frontend/src/redux/slices/swap/index.js
@@ -6,6 +6,7 @@ import { batch } from 'react-redux';
 import CONFIG from '../../../config';
 import FungibleTokens from '../../../services/FungibleTokens';
 import fungibleTokenExchange from '../../../services/tokenExchange';
+import { formatToken } from '../../../utils/token';
 import { wallet } from '../../../utils/wallet';
 import { getBalance } from '../../actions/account';
 import { showCustomAlert } from '../../actions/status';
@@ -92,10 +93,11 @@ const updateAllTokensData = createAsyncThunk(
                     fiatValueMetadata: tokenFiatValues.tokens[contractName] || {},
                 };
 
-                tokens[contractName] = config;
+                const formattedToken = formatToken(config);
+                tokens[contractName] = formattedToken;
 
                 if (balance > 0) {
-                    tokensWithBalance[contractName] = config;
+                    tokensWithBalance[contractName] = formattedToken;
                 }
             })
         );

--- a/packages/frontend/src/redux/slices/tokens/index.js
+++ b/packages/frontend/src/redux/slices/tokens/index.js
@@ -6,6 +6,7 @@ import { createSelector } from 'reselect';
 
 import CONFIG from '../../../config';
 import FungibleTokens from '../../../services/FungibleTokens';
+import { formatToken } from '../../../utils/token';
 import handleAsyncThunkStatus from '../../reducerStatus/handleAsyncThunkStatus';
 import initialStatusState from '../../reducerStatus/initialState/initialStatusState';
 import selectNEARAsTokenWithMetadata from '../../selectors/crossStateSelectors/selectNEARAsTokenWithMetadata';
@@ -88,10 +89,11 @@ const fetchTokens = createAsyncThunk(
                     fiatValueMetadata: tokenFiatValues.tokens[contractName] || {},
                 };
 
-                tokens[contractName] = tokenConfig;
+                const formattedToken = formatToken(tokenConfig);
+                tokens[contractName] = formattedToken;
 
                 if (Number(balance)) {
-                    tokensWithBalance[contractName] = tokenConfig;
+                    tokensWithBalance[contractName] = formattedToken;
                 }
             } catch (e) {
                 // Continue loading other likely contracts on failures

--- a/packages/frontend/src/translations/locales/en/translation.json
+++ b/packages/frontend/src/translations/locales/en/translation.json
@@ -1196,6 +1196,9 @@
             "balanceDetails": "Balance details",
             "transactionDetails": "Transaction Details"
         },
+        "enterAmount": {
+            "bridgedTokenWarning": "This is a bridged token. Do not send it to exchanges like Binance."
+        },
         "review": {
             "title": "You are sending"
         },

--- a/packages/frontend/src/translations/locales/it/translation.json
+++ b/packages/frontend/src/translations/locales/it/translation.json
@@ -1032,6 +1032,9 @@
             "balanceDetails": "Dettagli del Saldo",
             "transactionDetails": "Dettagli Transazione"
         },
+        "enterAmount": {
+            "bridgedTokenWarning": "Questo è un token collegato. Non inviarlo a scambi come Binance."
+        },
         "review": {
             "title": "Stai inviando"
         },

--- a/packages/frontend/src/translations/locales/pt/translation.json
+++ b/packages/frontend/src/translations/locales/pt/translation.json
@@ -996,6 +996,9 @@
             "balanceDetails": "Detalhes do saldo",
             "transactionDetails": "Detalhes da transação"
         },
+        "enterAmount": {
+            "bridgedTokenWarning": "Este é um token de ponte. Não o envie para exchanges como a Binance."
+        },
         "review": {
             "title": "Você está enviando"
         },

--- a/packages/frontend/src/translations/locales/ru/translation.json
+++ b/packages/frontend/src/translations/locales/ru/translation.json
@@ -901,6 +901,9 @@
             "balanceDetails": "Сведения о балансе",
             "transactionDetails": "Детали транзакции"
         },
+        "enterAmount": {
+            "bridgedTokenWarning": "Это мостовой токен. Не отправляйте его на биржи, такие как Binance."
+        },
         "review": {
             "title": "Вы отправляете"
         },

--- a/packages/frontend/src/translations/locales/tr/translation.json
+++ b/packages/frontend/src/translations/locales/tr/translation.json
@@ -978,6 +978,9 @@
             "balanceDetails": "Bakiye ayrıntıları",
             "transactionDetails": "İşlem Ayrıntıları"
         },
+        "enterAmount": {
+            "bridgedTokenWarning": "Bu bir köprü tokenidir. Binance gibi borsalara göndermeyin."
+        },
         "review": {
             "title": "Gönderiyorsunuz"
         },

--- a/packages/frontend/src/translations/locales/ua/translation.json
+++ b/packages/frontend/src/translations/locales/ua/translation.json
@@ -1061,6 +1061,9 @@
             "balanceDetails": "Відомості про баланс",
             "transactionDetails": "Деталі транзакції"
         },
+        "enterAmount": {
+            "bridgedTokenWarning": "Це токен-міст. Не відправляйте його на біржі, такі як Binance."
+        },
         "review": {
             "title": "ви надсилаєте"
         },

--- a/packages/frontend/src/translations/locales/vi/translation.json
+++ b/packages/frontend/src/translations/locales/vi/translation.json
@@ -926,6 +926,9 @@
             "balanceDetails": "Chi tiết Số dư",
             "transactionDetails": "Chi tiết Giao dịch"
         },
+        "enterAmount": {
+            "bridgedTokenWarning": "Đây là một token cầu nối. Đừng gửi nó đến các sàn giao dịch như Binance."
+        },
         "review": {
             "title": "Bạn đang gửi"
         },

--- a/packages/frontend/src/translations/locales/zh-hans/translation.json
+++ b/packages/frontend/src/translations/locales/zh-hans/translation.json
@@ -1167,6 +1167,9 @@
             "balanceDetails": "余额详情",
             "transactionDetails": "交易详情"
         },
+        "enterAmount": {
+            "bridgedTokenWarning": "这是一个跨链代币。请不要将其发送到交易所（如币安）。"
+        },
         "review": {
             "title": "你正在发送"
         },

--- a/packages/frontend/src/translations/locales/zh-hant/translation.json
+++ b/packages/frontend/src/translations/locales/zh-hant/translation.json
@@ -1167,6 +1167,9 @@
             "balanceDetails": "餘額詳情",
             "transactionDetails": "交易詳情"
         },
+        "enterAmount": {
+            "bridgedTokenWarning": "這是一個跨鏈代幣。請不要將其發送到交易所（如幣安）。"
+        },
         "review": {
             "title": "你正在發送"
         },

--- a/packages/frontend/src/utils/token.test.js
+++ b/packages/frontend/src/utils/token.test.js
@@ -1,0 +1,42 @@
+import * as SUT from './token';
+
+describe('Token utils', () => {
+    describe('formatToken', () => {
+        it.each([
+            ['usdt.fakes.testnet', { isBridged: true, symbol: 'Bridged USDT' }],
+            [
+                'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near',
+                { isBridged: true, symbol: 'Bridged USDT' },
+            ],
+            ['usdt.tether-token.near', { isBridged: false, symbol: 'Native USDT' }],
+            ['usdtt.fakes.testnet', { isBridged: false, symbol: 'Native USDT' }],
+            ['usdc.fakes.testnet', { isBridged: true, symbol: 'Bridged USDC' }],
+            [
+                'a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near',
+                { isBridged: true, symbol: 'Bridged USDC' },
+            ],
+            ['something else', { symbol: 'SOMETHING ELSE' }],
+        ])(
+            'when token contract name is %s it transforms the token to %o without changing anything else',
+            (contractName, expected) => {
+                const token = {
+                    contractName,
+                    onChainFTMetadata: {
+                        name: 'stays the same',
+                        symbol: 'SOMETHING ELSE',
+                    },
+                };
+
+                const result = SUT.formatToken(token);
+
+                expect(result).toEqual({
+                    contractName,
+                    onChainFTMetadata: {
+                        name: 'stays the same',
+                        ...expected,
+                    },
+                });
+            }
+        );
+    });
+});

--- a/packages/frontend/src/utils/token.ts
+++ b/packages/frontend/src/utils/token.ts
@@ -1,0 +1,56 @@
+enum ETokenContractId {
+    BridgedUSDTTestnet = 'usdt.fakes.testnet',
+    BridgedUSDT = 'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near',
+    NativeUSDTTestnet = 'usdtt.fakes.testnet',
+    NativeUSDT = 'usdt.tether-token.near',
+    BridgedUSDCTestnet = 'usdc.fakes.testnet',
+    BridgedUSDC = 'a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near',
+}
+
+interface ITokenContractIdMap {
+    isBridged: boolean;
+    symbol: string;
+}
+
+export const tokenContractIdSymbolMap: { [contractName: string]: ITokenContractIdMap } = {
+    [ETokenContractId.BridgedUSDTTestnet]: {
+        isBridged: true,
+        symbol: 'Bridged USDT',
+    },
+    [ETokenContractId.BridgedUSDT]: {
+        isBridged: true,
+        symbol: 'Bridged USDT',
+    },
+    [ETokenContractId.NativeUSDT]: {
+        isBridged: false,
+        symbol: 'Native USDT',
+    },
+    [ETokenContractId.NativeUSDTTestnet]: {
+        isBridged: false,
+        symbol: 'Native USDT',
+    },
+    [ETokenContractId.BridgedUSDC]: {
+        isBridged: true,
+        symbol: 'Bridged USDC',
+    },
+    [ETokenContractId.BridgedUSDCTestnet]: {
+        isBridged: true,
+        symbol: 'Bridged USDC',
+    },
+};
+
+export const formatToken = (token: Wallet.Token) => {
+    const { contractName } = token;
+
+    if (Object.keys(tokenContractIdSymbolMap).includes(contractName)) {
+        return {
+            ...token,
+            onChainFTMetadata: {
+                ...token.onChainFTMetadata,
+                ...tokenContractIdSymbolMap[contractName],
+            },
+        };
+    }
+
+    return token;
+};

--- a/packages/frontend/src/wallet.d.ts
+++ b/packages/frontend/src/wallet.d.ts
@@ -13,6 +13,7 @@ declare module Wallet {
             reference_hash: string | null;
             spec: string;
             symbol: string;
+            isBridged?: boolean;
         };
         fiatValueMetadata: {
             last_updated_at: number;


### PR DESCRIPTION
## Issues
Change some of the token's symbol to more human readable.
eg: Bridged USDT, Native USDT

The work is largely based on https://github.com/mynearwallet/my-near-wallet/pull/126

## Work done
### Frontend
- [x] change to human readable token name for bridged/native token 
- [x] show warning message in send page when bridged token is selected 
### E2E
- [x] Add e2e test for change token name
- [x] Add e2e test to check warning is shown when bridged token is selected in send page
