### PR TITLE
[calimero] change sync endpoint and call payload

### DIFF
--- a/packages/frontend/src/config/configFromEnvironment.ts
+++ b/packages/frontend/src/config/configFromEnvironment.ts
@@ -91,4 +91,5 @@ export default {
     REF_FINANCE_CONTRACT: process.env.REF_FINANCE_CONTRACT,
     HAPI_PROTOCOL_ADDRESS: process.env.HAPI_PROTOCOL_ADDRESS,
     CALIMERO_URL: process.env.CALIMERO_URL,
+    CALIMERO_API_URL: process.env.CALIMERO_API_URL
 };

--- a/packages/frontend/src/config/environmentDefaults/development.ts
+++ b/packages/frontend/src/config/environmentDefaults/development.ts
@@ -52,4 +52,5 @@ export default {
     USDT_CONTRACT: 'usdt.fakes.testnet',
     HAPI_PROTOCOL_ADDRESS: 'proxy.contracts.sergei24.testnet',
     CALIMERO_URL: 'https://app.calimero.network',
+    CALIMERO_API_URL: 'https://api.calimero.network'
 };

--- a/packages/frontend/src/config/environmentDefaults/mainnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.ts
@@ -58,4 +58,5 @@ export default {
     USDT_CONTRACT: 'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near',
     HAPI_PROTOCOL_ADDRESS: 'proxy.hapiprotocol.near',
     CALIMERO_URL: 'https://app.calimero.network',
+    CALIMERO_API_URL: 'https://api.calimero.network'
 };

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
@@ -58,4 +58,5 @@ export default {
     USDT_CONTRACT: 'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near',
     HAPI_PROTOCOL_ADDRESS: 'proxy.hapiprotocol.near',
     CALIMERO_URL: 'https://app.calimero.network',
+    CALIMERO_API_URL: 'https://api.calimero.network'
 };

--- a/packages/frontend/src/config/environmentDefaults/testnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet.ts
@@ -52,4 +52,5 @@ export default {
     USDT_CONTRACT: 'usdt.fakes.testnet',
     HAPI_PROTOCOL_ADDRESS: 'proxy.contracts.sergei24.testnet',
     CALIMERO_URL: 'https://app.calimero.network',
+    CALIMERO_API_URL: 'https://api.calimero.network'
 };

--- a/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
@@ -52,4 +52,5 @@ export default {
     USDT_CONTRACT: 'usdt.fakes.testnet',
     HAPI_PROTOCOL_ADDRESS: 'proxy.contracts.sergei24.testnet',
     CALIMERO_URL: 'https://app.calimero.network',
+    CALIMERO_API_URL: 'https://api.calimero.network'
 };

--- a/packages/frontend/src/services/PrivateShard.js
+++ b/packages/frontend/src/services/PrivateShard.js
@@ -13,12 +13,14 @@ export async function syncPrivateShardAccount({
         publicKey,
         signature,
         shardId: shardInfo.shardId,
+        method: 'sync',
     };
-    const response = await fetch(`${CONFIG.CALIMERO_URL}/api/public/sync`, {
+    const response = await fetch(`${CONFIG.CALIMERO_API_URL}/api/v1/shards/${shardInfo.shardId}/wallet/api/v1/account/sync`, {
         method: 'POST',
         body: JSON.stringify(postData),
         headers: {
             'Content-type': 'application/json; charset=utf-8',
+            'x-api-key': shardInfo.shardApiToken
         },
     });
     if (!response.ok) {


### PR DESCRIPTION
## Issues

 1. The Calimero authentication token (x-api-token) was not included in the API headers.
 2. The body was missing the call method.

## Changes Description

 1. The sync function now directly calls the Calimero gateway API instead of the Calimero console API.
 2. The "method" field has been added to the body.
 3. The "x-api-key" has been added to the call headers.

The purpose of these changes is to verify that the passed x-api-key has the appropriate permissions for "sync" and that the permission matches the value of the method passed in the body.


