### PR TITLE
fix: stop creating FullAccessKey when recovering account

### DIFF
--- a/packages/frontend/src/utils/wallet.js
+++ b/packages/frontend/src/utils/wallet.js
@@ -1540,21 +1540,21 @@ export default class Wallet {
                 account.inMemorySigner = account.connection.signer =
                     new nearApiJs.InMemorySigner(tempKeyStore);
 
-                const newKeyPair = nearApiJs.KeyPair.fromRandom('ed25519');
+                // const newKeyPair = nearApiJs.KeyPair.fromRandom('ed25519');
 
                 try {
-                    const methodNames = '';
-                    await this.addAccessKey(
-                        accountId,
-                        accountId,
-                        newKeyPair.publicKey,
-                        shouldCreateFullAccessKey,
-                        methodNames,
-                        recoveryKeyIsFAK
-                    );
+                    // const methodNames = '';
+                    // await this.addAccessKey(
+                    //     accountId,
+                    //     accountId,
+                    //     newKeyPair.publicKey,
+                    //     shouldCreateFullAccessKey,
+                    //     methodNames,
+                    //     recoveryKeyIsFAK
+                    // );
                     accountIdsSuccess.push({
                         accountId,
-                        newKeyPair,
+                        keyPair,
                     });
                 } catch (error) {
                     console.error(error);


### PR DESCRIPTION
## Issues

Main-T-224 MNW is creating FullAccessKey every time it recovers from seed phrase or private key

## Changes description

Stopping it from creating the FullAccessKey

## Important Note

This changes is not meant to be long term, it is meant to be a hot fix. After PR #145 resolves, definitely the whole `recoverAccountSecretKey` and related functions need to be rewritten, they are too messy.
