### PR TITLE
Update transaction -> txns to support NEARBlocks URI Format

### DIFF
--- a/packages/frontend/src/components/send/SendContainerV2.js
+++ b/packages/frontend/src/components/send/SendContainerV2.js
@@ -281,7 +281,7 @@ const SendContainerV2 = ({
                         onClickContinue={() => redirectTo('/')}
                         onClickGoToExplorer={() =>
                             window.open(
-                                `${explorerUrl}/transactions/${transactionHash}`,
+                                `${explorerUrl}/txns/${transactionHash}`,
                                 '_blank'
                             )
                         }


### PR DESCRIPTION
## Issues

Updated the explorer URI from the legacy explorer /transactions to the NEARBlocks.io txn

## Changes description

Update /transactions to /txns to match NEARBlocks expected URI format

## Preview

1. Send 1N to another address
2. Click "View in Explorer" 
3. FIX: Link now takes the user to the actual transaction in NEARBlocks instead of a 404 page

## Demo
