### PR TITLE
Improve style for accountId in sign-message route

### DIFF
--- a/packages/frontend/src/components/sign-message/SignMessage.js
+++ b/packages/frontend/src/components/sign-message/SignMessage.js
@@ -25,6 +25,7 @@ const StyledContainer = styled.div`
         color: #272729;
         text-align: center;
         line-height: 130%;
+        word-break: break-word;
     }
 
     > .icon {


### PR DESCRIPTION
## Issues

<!-- List of issues this pull request is related to or solves  -->

This PR improves the CSS style on the `sign-message` route for the long accountId (e.g. implicit accountIds) name.

## Changes description

<!-- Changes description -->

Fixes text overflow.

## Preview

#### Before
![image](https://github.com/mynearwallet/my-near-wallet/assets/95851345/937a10ad-e0ee-41f8-b55a-e6a1e5d5c355)


#### After
![after](https://github.com/mynearwallet/my-near-wallet/assets/95851345/d532d282-df3b-42ef-8ff6-e82b49a175cf)

<!-- Any information that helps to see the result of the changes: images, links, etc. -->

## Demo

<!-- If this is possible and these are complex changes, attach a demo for them  -->