### PR TITLE
fix: User can't claim FT from staking pool

### DIFF
--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -780,11 +780,13 @@ export const claimFarmRewards = (validatorId, token_id) => async (dispatch, getS
             ...validators.find((validator) => validator?.accountId === validatorId),
         };
 
-        const storageAvailable = await fungibleTokensService.isStorageBalanceAvailable({
-            contractName: token_id,
-            accountId: accountId,
-        });
-        if (!storageAvailable) {
+        const isStorageDepositRequired =
+            await fungibleTokensService.isStorageDepositRequired({
+                contractName: token_id,
+                accountId: accountId,
+            });
+
+        if (isStorageDepositRequired) {
             try {
                 const account = await wallet.getAccount(accountId);
                 await fungibleTokensService.transferStorageDeposit({


### PR DESCRIPTION
Some staking pool reward user with fungible tokens, such as `aurora.pool.near`

This patch fixes the bug where user can't claim staking rewards from this kind of pool