### PR TITLE
refactor: move blacklisted tokens feature to originally designed place

### DIFF
--- a/packages/frontend/src/components/common/token/TokenBox.js
+++ b/packages/frontend/src/components/common/token/TokenBox.js
@@ -182,8 +182,6 @@ const SubTitle = ({ showFiatPrice, price, currentLanguage, name = '-' }) => {
     );
 };
 
-const blacklistedTokens = ['congratulations.laboratory.jumpfinance.near'];
-
 const TokenBox = ({ token, onClick, currentLanguage, showFiatPrice = false }) => {
     const { symbol = '', name = '', icon = '' } = token.onChainFTMetadata;
 
@@ -192,10 +190,6 @@ const TokenBox = ({ token, onClick, currentLanguage, showFiatPrice = false }) =>
             onClick(token);
         }
     };
-
-    if (blacklistedTokens.includes(token.contractName)) {
-        return <></>;
-    }
 
     return (
         <StyledContainer

--- a/packages/frontend/src/redux/slices/security/temp_blacklisted_tokens.json
+++ b/packages/frontend/src/redux/slices/security/temp_blacklisted_tokens.json
@@ -4,5 +4,8 @@
     },
     {
         "address": "adtoken.near"
+    },
+    {
+        "address": "congratulations.laboratory.jumpfinance.near"
     }
 ]


### PR DESCRIPTION
It appears that blacklisting a tokens is not a new feature. it is something already done previously.

So I removed the newly added code, and move the blacklisted tokens to the place where it originally is designed.