### PR TITLE
fix: user can't import account with seed phrase

### DIFF
--- a/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -138,6 +138,7 @@ class RecoverAccountSeedPhrase extends Component {
         const fundWithExistingAccount = parseQuery(location.search, {
             parseBooleans: true,
         }).fundWithExistingAccount;
+
         if (fundWithExistingAccount) {
             const createNewAccountParams = stringify(JSON.parse(fundWithExistingAccount));
             redirectTo(`/fund-with-existing-account?${createNewAccountParams}`);

--- a/packages/frontend/src/config/environmentDefaults/development.ts
+++ b/packages/frontend/src/config/environmentDefaults/development.ts
@@ -12,6 +12,7 @@ export default {
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     INDEXER_SERVICE_URL: 'https://testnet-api.kitwallet.app',
+    INDEXER_NEARBLOCK_SERVICE_URL: 'https://api-testnet.nearblocks.io',
     LINKDROP_GAS: '100000000000000',
     LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.devnet',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),

--- a/packages/frontend/src/config/environmentDefaults/mainnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.ts
@@ -13,6 +13,7 @@ export default {
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     INDEXER_SERVICE_URL: 'https://api.kitwallet.app',
+    INDEXER_NEARBLOCK_SERVICE_URL: 'https://api.nearblocks.io',
     LINKDROP_GAS: '100000000000000',
     LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.near',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
@@ -13,6 +13,7 @@ export default {
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     INDEXER_SERVICE_URL: 'https://staging-api.kitwallet.app',
+    INDEXER_NEARBLOCK_SERVICE_URL: 'https://api.nearblocks.io',
     LINKDROP_GAS: '100000000000000',
     LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.near',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),

--- a/packages/frontend/src/config/environmentDefaults/testnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet.ts
@@ -13,6 +13,7 @@ export default {
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     INDEXER_SERVICE_URL: 'https://testnet-api.kitwallet.app',
+    INDEXER_NEARBLOCK_SERVICE_URL: 'https://api-testnet.nearblocks.io',
     LINKDROP_GAS: '100000000000000',
     LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.devnet',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),

--- a/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
@@ -13,6 +13,7 @@ export default {
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     INDEXER_SERVICE_URL: 'https://preflight-api.kitwallet.app',
+    INDEXER_NEARBLOCK_SERVICE_URL: 'https://api-testnet.nearblocks.io',
     LINKDROP_GAS: '100000000000000',
     LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.m0',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),

--- a/packages/frontend/src/services/indexer/api.js
+++ b/packages/frontend/src/services/indexer/api.js
@@ -6,11 +6,23 @@ import { CUSTOM_REQUEST_HEADERS } from '../../utils/constants';
 
 export default {
     listAccountsByPublicKey: (publicKey) => {
-        return fetch(`${CONFIG.INDEXER_SERVICE_URL}/publicKey/${publicKey}/accounts`, {
-            headers: {
-                ...CUSTOM_REQUEST_HEADERS,
-            },
-        }).then((res) => res.json());
+        return Promise.all([
+            fetch(`${CONFIG.INDEXER_SERVICE_URL}/publicKey/${publicKey}/accounts`, {
+                headers: {
+                    ...CUSTOM_REQUEST_HEADERS,
+                },
+            }).then((res) => res.json()),
+            fetch(`${CONFIG.INDEXER_NEARBLOCK_SERVICE_URL}/v1/keys//${publicKey}`, {
+                headers: {
+                    accept: '*/*',
+                },
+            })
+                .then((res) => res.json())
+                .then((res) => res.keys.map((key) => key.account_id)),
+        ]).then(([accounts, accountsFromNearblock]) => [
+            ...accounts,
+            ...accountsFromNearblock,
+        ]);
     },
     listLikelyNfts: (accountId, timestamp) => {
         const url = `${CONFIG.INDEXER_SERVICE_URL}/account/${accountId}/likelyNFTsFromBlock`;

--- a/packages/frontend/src/services/indexer/api.js
+++ b/packages/frontend/src/services/indexer/api.js
@@ -12,7 +12,7 @@ export default {
                     ...CUSTOM_REQUEST_HEADERS,
                 },
             }).then((res) => res.json()),
-            fetch(`${CONFIG.INDEXER_NEARBLOCK_SERVICE_URL}/v1/keys//${publicKey}`, {
+            fetch(`${CONFIG.INDEXER_NEARBLOCK_SERVICE_URL}/v1/keys/${publicKey}`, {
                 headers: {
                     accept: '*/*',
                 },

--- a/packages/frontend/src/services/indexer/api.js
+++ b/packages/frontend/src/services/indexer/api.js
@@ -20,8 +20,7 @@ export default {
                 .then((res) => res.json())
                 .then((res) => res.keys.map((key) => key.account_id)),
         ]).then(([accounts, accountsFromNearblock]) => [
-            ...accounts,
-            ...accountsFromNearblock,
+            ...new Set([...accounts, ...accountsFromNearblock]),
         ]);
     },
     listLikelyNfts: (accountId, timestamp) => {


### PR DESCRIPTION
This happens when the user created an account, then import it using seed phrase within a very short period.

Kitwallet API is slow when registering changes.

I have added NearBlocks API.

The original Kitwallet API is not removed, instead, now the wallet will call both the Indexer, and merge their results together.

By doing so, we remove the single point of failure...

Now, no matter kitwallet is failing or nearblocks is failing, our wallet won't be affected. Our wallet will only be affected if both the indexer fails.