### PR TITLE
fix: add error catching into fetching accounts from indexer based on …

### DIFF
--- a/packages/frontend/src/services/indexer/api.js
+++ b/packages/frontend/src/services/indexer/api.js
@@ -11,14 +11,23 @@ export default {
                 headers: {
                     ...CUSTOM_REQUEST_HEADERS,
                 },
-            }).then((res) => res.json()),
+            })
+                .then((res) => res.json())
+                .catch((err) => {
+                    console.warn('Error fetching accounts from kitwallet indexer', err);
+                    return [];
+                }),
             fetch(`${CONFIG.INDEXER_NEARBLOCK_SERVICE_URL}/v1/keys/${publicKey}`, {
                 headers: {
                     accept: '*/*',
                 },
             })
                 .then((res) => res.json())
-                .then((res) => res.keys.map((key) => key.account_id)),
+                .then((res) => res.keys.map((key) => key.account_id))
+                .catch((err) => {
+                    console.warn('Error fetching accounts from nearblock', err);
+                    return [];
+                }),
         ]).then(([accounts, accountsFromNearblock]) => [
             ...new Set([...accounts, ...accountsFromNearblock]),
         ]);


### PR DESCRIPTION
…public key

When any of the indexer is having error, then the fetching accounts by seed phrase or private key will fail.

This PR solve the problem by adding proper error handling.