### PR TITLE
fix: filter weird symbol FT tokens

### DIFF
--- a/packages/frontend/src/redux/slices/tokens/index.js
+++ b/packages/frontend/src/redux/slices/tokens/index.js
@@ -281,11 +281,17 @@ export const selectAllowedTokens = createSelector(
             fiatValueMetadata: tokensFiatData[tokenData.contractName] || {},
         }));
 
+        const safeTokenList = tokenList
+            .filter(({ onChainFTMetadata }) => onChainFTMetadata.symbol.length < 10)
+            .filter(({ onChainFTMetadata }) =>
+                onChainFTMetadata.symbol.match(/^[a-zA-Z0-9]+$/)
+            );
+
         if (![...setOfBlacklistedNames].length) {
-            return [nearConfigWithName, ...tokenList];
+            return [nearConfigWithName, ...safeTokenList];
         }
 
-        const allowedTokens = tokenList.filter(
+        const allowedTokens = safeTokenList.filter(
             ({ contractName }) => !setOfBlacklistedNames.has(contractName)
         );
 


### PR DESCRIPTION
All FT tokens will be filter out if:

- Their length is more than 10 characters, including 10
- They contain any character except these: "a-z", "A-Z", "0~9"
