### PR TITLE
refactor: not passing signer into external library

### DIFF
--- a/packages/frontend/src/redux/actions/account.js
+++ b/packages/frontend/src/redux/actions/account.js
@@ -265,10 +265,11 @@ export const allowLogin = () => async (dispatch, getState) => {
             rpcEndpoint: shardInfo.shardRpc,
             walletNetworkId: CONFIG.NETWORK_ID,
         };
-        const walletUtils = CalimeroWalletUtils.init(calimeroConfig);
-        const account = await wallet.getAccount(wallet.accountId);
-        const signer = account.signerIgnoringLedger || account.connection.signer;
-        await walletUtils.syncPrivateShardAccount(account.accountId, signer);
+
+        const calimeroWalletUtils = CalimeroWalletUtils.init(calimeroConfig);
+        const xSignature = await wallet.generatePrivateShardXSignature(shardInfo);
+
+        await calimeroWalletUtils.syncAccount(wallet.accountId, xSignature);
     }
 
     const addAccessKeyAction = shardInfo ? addShardAccessKey : addAccessKey;


### PR DESCRIPTION
## Modification of PR #179

### Reason for Modification:
The changes introduced in PR #179 are being modified due to the following concerns:

 1.⁠ ⁠*Signer Passing to External Library:* In line 271, the PR passes our signer to an external library, which raises concerns about the security of our application.

 2.⁠ ⁠*External Library Inspection:* We have thoroughly reviewed the external library, "calimero-wallet-utils," up to version 0.0.1 and found no issues. However, it's important to note that the library's version is specified with a caret "^," indicating that future updates to the external library could potentially introduce security risks as our signer is being passed to it.

We are modifying these changes to ensure the security and stability of our application.

### Changes:

1. "signer" is no longer being passed into the external library.

2. Since "signer" is no longer being passed, we remains the caret "^" in front the external library package.