### PR TITLE
fix: whitelist USDC.e and USDT.e

### DIFF
--- a/packages/frontend/src/redux/slices/tokens/index.js
+++ b/packages/frontend/src/redux/slices/tokens/index.js
@@ -94,6 +94,7 @@ const fetchTokens = createAsyncThunk(
                         contractName,
                         getState()
                     );
+
                     const balance = await FungibleTokens.getBalanceOf({
                         contractName,
                         accountId,
@@ -281,11 +282,23 @@ export const selectAllowedTokens = createSelector(
             fiatValueMetadata: tokensFiatData[tokenData.contractName] || {},
         }));
 
-        const safeTokenList = tokenList
-            .filter(({ onChainFTMetadata }) => onChainFTMetadata.symbol.length < 10)
-            .filter(({ onChainFTMetadata }) =>
-                onChainFTMetadata.symbol.match(/^[a-zA-Z0-9]+$/)
-            );
+        const safeTokenList = tokenList.filter(
+            ({ onChainFTMetadata, fiatValueMetadata }) => {
+                if (fiatValueMetadata?.usd) {
+                    return true;
+                }
+
+                if (onChainFTMetadata.symbol.length >= 10) {
+                    return false;
+                }
+
+                if (!onChainFTMetadata.symbol.match(/^[a-zA-Z0-9]+$/)) {
+                    return false;
+                }
+
+                return true;
+            }
+        );
 
         if (![...setOfBlacklistedNames].length) {
             return [nearConfigWithName, ...safeTokenList];

--- a/packages/frontend/src/redux/slices/tokens/index.js
+++ b/packages/frontend/src/redux/slices/tokens/index.js
@@ -282,23 +282,21 @@ export const selectAllowedTokens = createSelector(
             fiatValueMetadata: tokensFiatData[tokenData.contractName] || {},
         }));
 
-        const safeTokenList = tokenList.filter(
-            ({ onChainFTMetadata, fiatValueMetadata }) => {
-                if (fiatValueMetadata?.usd) {
-                    return true;
-                }
-
-                if (onChainFTMetadata.symbol.length >= 10) {
-                    return false;
-                }
-
-                if (!onChainFTMetadata.symbol.match(/^[a-zA-Z0-9]+$/)) {
-                    return false;
-                }
-
+        const safeTokenList = tokenList.filter(({ onChainFTMetadata }) => {
+            if (['USDC.e', 'USDT.e'].includes(onChainFTMetadata.symbol)) {
                 return true;
             }
-        );
+
+            if (onChainFTMetadata.symbol.length >= 10) {
+                return false;
+            }
+
+            if (!onChainFTMetadata.symbol.match(/^[a-zA-Z0-9]+$/)) {
+                return false;
+            }
+
+            return true;
+        });
 
         if (![...setOfBlacklistedNames].length) {
             return [nearConfigWithName, ...safeTokenList];


### PR DESCRIPTION
Tokens such as USDC.e is not showing after PR-181 patch because it contains invalid symbol such as "decimal"

After some consideration, we don't want to "allow" any symbol.

Instead of allowing symbol, we will whitelist "USDC.e" and "USDT.e"