### PR TITLE
fix: showing USDT.e and USDC.e

### DIFF
--- a/packages/frontend/src/redux/slices/tokens/index.js
+++ b/packages/frontend/src/redux/slices/tokens/index.js
@@ -283,7 +283,8 @@ export const selectAllowedTokens = createSelector(
         }));
 
         const safeTokenList = tokenList.filter(({ onChainFTMetadata }) => {
-            if (['USDC.e', 'USDT.e'].includes(onChainFTMetadata.symbol)) {
+            console.log(onChainFTMetadata.symbol);
+            if (['Bridged USDC', 'Bridged USDT'].includes(onChainFTMetadata.symbol)) {
                 return true;
             }
 

--- a/packages/frontend/src/redux/slices/tokens/index.js
+++ b/packages/frontend/src/redux/slices/tokens/index.js
@@ -283,7 +283,6 @@ export const selectAllowedTokens = createSelector(
         }));
 
         const safeTokenList = tokenList.filter(({ onChainFTMetadata }) => {
-            console.log(onChainFTMetadata.symbol);
             if (['Bridged USDC', 'Bridged USDT'].includes(onChainFTMetadata.symbol)) {
                 return true;
             }


### PR DESCRIPTION
## Issues
Fixing an issue where Bridged USDT and Bridged USDC are not showing. This issue happened earlier due to a previous commit that's trying gatekeep users from phishing tokens. Both "Bridged USDT/USDC" have longer than 10 characters symbols and were both blocked. 

## Changes description
Added a condition check to just let both tokens go through

## Preview
![image](https://github.com/mynearwallet/my-near-wallet/assets/70085530/8d151965-37c8-44b4-8a5d-941e1a2148e1)

