### PR TITLE
fix: set a default language code when current language is not available

### DIFF
--- a/packages/frontend/src/hooks/getCurrentLanguage.js
+++ b/packages/frontend/src/hooks/getCurrentLanguage.js
@@ -8,7 +8,7 @@ const getLanguageSelector = createSelector(getLanguagesList, (languages) =>
 
 function getCurrentLanguage() {
     const currentLanguage = useSelector(getLanguageSelector);
-    return currentLanguage.code;
+    return currentLanguage?.code ?? 'en';
 }
 
 export default getCurrentLanguage;


### PR DESCRIPTION
When the currentLanguage is undefined, reading "code" will cause the code to throw error.

This PR edit the code to give a default value when currentLanguage?.code is undefined.