### PR TITLE
fix: adding timeout to import account indexer apis

### DIFF
--- a/packages/frontend/src/services/indexer/api.ts
+++ b/packages/frontend/src/services/indexer/api.ts
@@ -4,25 +4,34 @@ import { NearBlocksTxnsResponse } from './type';
 import CONFIG from '../../config';
 import sendJson from '../../tmp_fetch_send_json';
 import { CUSTOM_REQUEST_HEADERS } from '../../utils/constants';
+import { fetchWithTimeout } from '../../utils/request';
 
 export default {
     listAccountsByPublicKey: (publicKey) => {
         return Promise.all([
-            fetch(`${CONFIG.INDEXER_SERVICE_URL}/publicKey/${publicKey}/accounts`, {
-                headers: {
-                    ...CUSTOM_REQUEST_HEADERS,
+            fetchWithTimeout(
+                `${CONFIG.INDEXER_SERVICE_URL}/publicKey/${publicKey}/accounts`,
+                {
+                    headers: {
+                        ...CUSTOM_REQUEST_HEADERS,
+                    },
                 },
-            })
+                10000
+            )
                 .then((res) => res.json())
                 .catch((err) => {
                     console.warn('Error fetching accounts from kitwallet indexer', err);
                     return [];
                 }),
-            fetch(`${CONFIG.INDEXER_NEARBLOCK_SERVICE_URL}/v1/keys/${publicKey}`, {
-                headers: {
-                    accept: '*/*',
+            fetchWithTimeout(
+                `${CONFIG.INDEXER_NEARBLOCK_SERVICE_URL}/v1/keys/${publicKey}`,
+                {
+                    headers: {
+                        accept: '*/*',
+                    },
                 },
-            })
+                10000
+            )
                 .then((res) => res.json())
                 .then((res) => res.keys.map((key) => key.account_id))
                 .catch((err) => {

--- a/packages/frontend/src/utils/request.js
+++ b/packages/frontend/src/utils/request.js
@@ -10,3 +10,28 @@ export const retryRequestIfFailed = async (callback, { attempts = 1, delay = 100
 
     return;
 };
+
+// Function to implement a timeout
+function timeout(ms, promise) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            reject(new Error('Timeout after ' + ms + ' ms')); // Rejects the promise after timeout
+        }, ms);
+
+        promise.then(
+            (res) => {
+                clearTimeout(timer);
+                resolve(res);
+            },
+            (err) => {
+                clearTimeout(timer);
+                reject(err);
+            }
+        );
+    });
+}
+
+// Function to fetch with a timeout
+export function fetchWithTimeout(url, options, timeoutMs = 5000) {
+    return timeout(timeoutMs, fetch(url, options));
+}


### PR DESCRIPTION
Adding a new method, fetchWithTimeout, to improve fetching account IDs from indexers. This resolves issues caused by slow indexers, ensuring the feature works more reliably.