### PR TITLE
fix: replacing kitwallet api with rpc in getStakingDeposits metho

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,22 +31,6 @@ module.exports = {
         'no-extra-semi': 'off',
         'no-irregular-whitespace': 'off',
         'import/named': ['error', 'always'],
-        'import/order': [
-            'error',
-            {
-                alphabetize: {
-                    order: 'asc',
-                    caseInsensitive: true,
-                },
-                'newlines-between': 'always',
-                groups: [
-                    'builtin',
-                    ['external', 'internal'],
-                    ['sibling', 'parent', 'index'],
-                    'object',
-                ],
-            },
-        ],
         'max-statements-per-line': ['error', { max: 1 }],
         'no-process-env': ['error'],
         'no-restricted-globals': [

--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -6,7 +6,6 @@ import { createActions } from 'redux-actions';
 import { getBalance } from './account';
 import CONFIG from '../../config';
 import { fungibleTokensService } from '../../services/FungibleTokens';
-import { listStakingPools } from '../../services/indexer';
 import StakingFarmContracts from '../../services/StakingFarmContracts';
 import {
     getLockupAccountId,
@@ -530,9 +529,12 @@ export const { staking } = createActions({
                     wallet.connection.provider.connection.url.indexOf(MAINNET) > -1
                         ? MAINNET
                         : TESTNET;
-                const allStakingPools = await listStakingPools();
+                // const allStakingPools = await listStakingPools();
                 const prefix = getValidatorRegExp(networkId);
-                accountIds = [...new Set([...rpcValidators, ...allStakingPools])].filter(
+                // accountIds = [...new Set([...rpcValidators, ...allStakingPools])].filter(
+                //     (v) => v.indexOf('nfvalidator') === -1 && v.match(prefix)
+                // );
+                accountIds = [...new Set(rpcValidators)].filter(
                     (v) => v.indexOf('nfvalidator') === -1 && v.match(prefix)
                 );
             }


### PR DESCRIPTION
## Issues

Staking page breaks currently due to kitwallet api went down.

## Changes description
Replacing current getStakingDeposits method with RPC get_total_staked_balance method. Also get list of validators from rpc using rpc.validators() method


## Demo
![image](https://github.com/mynearwallet/my-near-wallet/assets/70085530/dd860eb3-d2ed-4585-bfca-0619e90281de)

