### PR TITLE
fix: set timeout to become 30 seconds

### DIFF
--- a/packages/frontend/src/services/indexer/api.ts
+++ b/packages/frontend/src/services/indexer/api.ts
@@ -4,7 +4,7 @@ import { NearBlocksTxnsResponse } from './type';
 import CONFIG from '../../config';
 import sendJson from '../../tmp_fetch_send_json';
 import { CUSTOM_REQUEST_HEADERS } from '../../utils/constants';
-import { fetchWithTimeout } from '../../utils/request';
+import { fetchWithTimeout, timeout } from '../../utils/request';
 import { accountsByPublicKey } from '@mintbase-js/data';
 
 export default {
@@ -17,7 +17,7 @@ export default {
                         ...CUSTOM_REQUEST_HEADERS,
                     },
                 },
-                10000
+                30000
             )
                 .then((res) => res.json())
                 .catch((err) => {
@@ -31,7 +31,7 @@ export default {
                         accept: '*/*',
                     },
                 },
-                10000
+                30000
             )
                 .then((res) => res.json())
                 .then((res) => res.keys.map((key) => key.account_id))
@@ -39,8 +39,11 @@ export default {
                     console.warn('Error fetching accounts from nearblock', err);
                     return [];
                 }),
-            accountsByPublicKey(publicKey, CONFIG.IS_MAINNET ? 'mainnet' : 'testnet')
-                .then(res => res.data)
+            timeout(
+                30000,
+                accountsByPublicKey(publicKey, CONFIG.IS_MAINNET ? 'mainnet' : 'testnet')
+            )
+                .then((res) => res.data ?? [])
                 .catch((err) => {
                     console.warn('Error fetching accounts from mintbase', err);
                     return [];

--- a/packages/frontend/src/utils/request.js
+++ b/packages/frontend/src/utils/request.js
@@ -12,7 +12,7 @@ export const retryRequestIfFailed = async (callback, { attempts = 1, delay = 100
 };
 
 // Function to implement a timeout
-function timeout(ms, promise) {
+export function timeout(ms, promise) {
     return new Promise((resolve, reject) => {
         const timer = setTimeout(() => {
             reject(new Error('Timeout after ' + ms + ' ms')); // Rejects the promise after timeout


### PR DESCRIPTION
At the current time of testing:

<img width="1194" alt="Screenshot 2024-02-19 at 12 57 25 PM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/754329ab-8a14-481f-a201-d66b55e76d65">

Mintbase API will inconsistently success after 40+ seconds or failed after 1 minutes.

---

<img width="1184" alt="Screenshot 2024-02-19 at 12 57 32 PM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/0e91da5a-5387-445a-b46f-e17bf97b85f3">

Kitwallet API will consistently failed after 1 minutes

---

<img width="1206" alt="Screenshot 2024-02-19 at 12 57 38 PM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/c7421263-51ed-4a0e-b090-ca8c9ba7f115">

Nearblocks API will consistently success after 10~30 seconds

---

I think a 30 seconds timeout is more reliable.