### PR TITLE
fix: change almost all kitwallet api to become nearblocks

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/development.ts
+++ b/packages/frontend/src/config/environmentDefaults/development.ts
@@ -3,6 +3,7 @@ import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
     ACCOUNT_HELPER_URL: 'https://testnet-api.kitwallet.app',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://testnet-api.kitwallet.app',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     DISABLE_CREATE_ACCOUNT: false,

--- a/packages/frontend/src/config/environmentDefaults/mainnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.ts
@@ -2,7 +2,8 @@ import * as nearApiJs from 'near-api-js';
 import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
-    ACCOUNT_HELPER_URL: 'https://api.kitwallet.app',
+    ACCOUNT_HELPER_URL: 'https://api3.nearblocks.io/v1/kitwallet',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://api.kitwallet.app',
     ACCOUNT_ID_SUFFIX: 'near',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     BROWSER_MIXPANEL_TOKEN: '7c5730e5b3556a06b73829b3c3b40a86',
@@ -12,7 +13,8 @@ export default {
     EXPLORER_URL: 'https://nearblocks.io',
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
-    INDEXER_SERVICE_URL: 'https://api.kitwallet.app',
+    // INDEXER_SERVICE_URL: 'https://api.kitwallet.app',
+    INDEXER_SERVICE_URL: 'https://api3.nearblocks.io/v1/kitwallet',
     INDEXER_NEARBLOCK_SERVICE_URL: 'https://api.nearblocks.io',
     INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api3.nearblocks.io',
     LINKDROP_GAS: '100000000000000',

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
@@ -2,7 +2,8 @@ import * as nearApiJs from 'near-api-js';
 import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
-    ACCOUNT_HELPER_URL: 'https://api.kitwallet.app',
+    ACCOUNT_HELPER_URL: 'https://api3.nearblocks.io/v1/kitwallet',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://api.kitwallet.app',
     ACCOUNT_ID_SUFFIX: 'near',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     BROWSER_MIXPANEL_TOKEN: '7c5730e5b3556a06b73829b3c3b40a86',
@@ -12,7 +13,8 @@ export default {
     EXPLORER_URL: 'https://nearblocks.io',
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
-    INDEXER_SERVICE_URL: 'https://api.kitwallet.app',
+    // INDEXER_SERVICE_URL: 'https://api.kitwallet.app',
+    INDEXER_SERVICE_URL: 'https://api3.nearblocks.io/v1/kitwallet',
     INDEXER_NEARBLOCK_SERVICE_URL: 'https://api.nearblocks.io',
     INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api3.nearblocks.io',
     LINKDROP_GAS: '100000000000000',

--- a/packages/frontend/src/config/environmentDefaults/testnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet.ts
@@ -3,6 +3,7 @@ import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
     ACCOUNT_HELPER_URL: 'https://testnet-api.kitwallet.app',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://testnet-api.kitwallet.app',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     BROWSER_MIXPANEL_TOKEN: '778bd24eec7329cf885f0cecfc3d4f5d',

--- a/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
@@ -3,6 +3,7 @@ import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
     ACCOUNT_HELPER_URL: 'https://testnet-api.kitwallet.app',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://testnet-api.kitwallet.app',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     BROWSER_MIXPANEL_TOKEN: '778bd24eec7329cf885f0cecfc3d4f5d',

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -1323,7 +1323,7 @@ export default class Wallet {
     }
 
     async postSignedJson(path, options) {
-        return await sendJson('POST', CONFIG.ACCOUNT_HELPER_URL + path, {
+        return await sendJson('POST', CONFIG.ACCOUNT_KITWALLET_HELPER_URL + path, {
             ...options,
             ...(await this.signatureFor(this)),
         });


### PR DESCRIPTION
Kitwallet API seems to be very slow currently.

We change it to the new API that nearblocks provide us.