### PR TITLE
feat: use fastnear API to import account

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/development.ts
+++ b/packages/frontend/src/config/environmentDefaults/development.ts
@@ -13,6 +13,7 @@ export default {
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     INDEXER_SERVICE_URL: 'https://testnet-api.kitwallet.app',
+    INDEXER_FASTNEAR_SERVICE_URL: 'https://api.fastnear.com',
     INDEXER_NEARBLOCK_SERVICE_URL: 'https://api-testnet.nearblocks.io',
     INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api-testnet.nearblocks.io',
     LINKDROP_GAS: '100000000000000',

--- a/packages/frontend/src/config/environmentDefaults/mainnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.ts
@@ -15,6 +15,7 @@ export default {
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     // INDEXER_SERVICE_URL: 'https://api.kitwallet.app',
     INDEXER_SERVICE_URL: 'https://api3.nearblocks.io/v1/kitwallet',
+    INDEXER_FASTNEAR_SERVICE_URL: 'https://api.fastnear.com',
     INDEXER_NEARBLOCK_SERVICE_URL: 'https://api.nearblocks.io',
     INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api3.nearblocks.io',
     LINKDROP_GAS: '100000000000000',

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
@@ -15,6 +15,7 @@ export default {
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     // INDEXER_SERVICE_URL: 'https://api.kitwallet.app',
     INDEXER_SERVICE_URL: 'https://api3.nearblocks.io/v1/kitwallet',
+    INDEXER_FASTNEAR_SERVICE_URL: 'https://api.fastnear.com',
     INDEXER_NEARBLOCK_SERVICE_URL: 'https://api.nearblocks.io',
     INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api3.nearblocks.io',
     LINKDROP_GAS: '100000000000000',

--- a/packages/frontend/src/config/environmentDefaults/testnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet.ts
@@ -14,6 +14,7 @@ export default {
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     INDEXER_SERVICE_URL: 'https://testnet-api.kitwallet.app',
+    INDEXER_FASTNEAR_SERVICE_URL: 'https://api.fastnear.com',
     INDEXER_NEARBLOCK_SERVICE_URL: 'https://api-testnet.nearblocks.io',
     INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api-testnet.nearblocks.io',
     LINKDROP_GAS: '100000000000000',

--- a/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
@@ -14,6 +14,7 @@ export default {
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     INDEXER_SERVICE_URL: 'https://testnet-api.kitwallet.app',
+    INDEXER_FASTNEAR_SERVICE_URL: 'https://api.fastnear.com',
     INDEXER_NEARBLOCK_SERVICE_URL: 'https://api-testnet.nearblocks.io',
     INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api-testnet.nearblocks.io',
     LINKDROP_GAS: '100000000000000',


### PR DESCRIPTION
## Description

User is reporting that they can't find all their account when trying to import with ledger.

After our debugging, we found out that maybe Nearblocks v1 api doesn't capture every account properly.

We added fastnear API to support the account import, while also remove nearblocks v1.

## Changes
+ Add fastnear API for checking account with public key when importing account
- Remove nearblocks v1 for checking account with public key when importing account