### PR TITLE
fix: not all validators support staking

### DIFF
--- a/packages/frontend/src/utils/account-with-lockup.ts
+++ b/packages/frontend/src/utils/account-with-lockup.ts
@@ -253,7 +253,7 @@ async function getAccountBalance(limitedAccountData = false) {
                             err.message.includes('CompilationError(CodeDoesNotExist') ||
                             err.message.includes('MethodResolveError(MethodNotFound)')
                         ) {
-                            return 0;
+                            return '0';
                         } else {
                             throw err;
                         }

--- a/packages/frontend/src/utils/staking.ts
+++ b/packages/frontend/src/utils/staking.ts
@@ -89,13 +89,22 @@ export async function getStakingDeposits(accountId: string) {
     let validatorWithBalance = await Promise.all(
         validatorIds.map(async (validatorId) => {
             const account = wallet.getAccountBasic(accountId);
-            const balance = await account.viewFunction(
-                validatorId,
-                'get_account_total_balance',
-                {
+            const balance = await account
+                .viewFunction(validatorId, 'get_account_total_balance', {
                     account_id: accountId,
-                }
-            );
+                })
+                .catch((err) => {
+                    if (
+                        // Means the validators  don't have contract deployed, or don't support staking
+                        err.message.includes('CompilationError(CodeDoesNotExist') ||
+                        err.message.includes('MethodResolveError(MethodNotFound)')
+                    ) {
+                        return 0;
+                    } else {
+                        throw err;
+                    }
+                });
+
             return { validator_id: validatorId, deposit: balance } as {
                 validator_id: string;
                 deposit: string;

--- a/packages/frontend/src/utils/staking.ts
+++ b/packages/frontend/src/utils/staking.ts
@@ -99,7 +99,7 @@ export async function getStakingDeposits(accountId: string) {
                         err.message.includes('CompilationError(CodeDoesNotExist') ||
                         err.message.includes('MethodResolveError(MethodNotFound)')
                     ) {
-                        return 0;
+                        return '0';
                     } else {
                         throw err;
                     }


### PR DESCRIPTION
Users are reporting about the issue that they can't see their Near balance.

<img width="839" alt="Screenshot 2024-03-01 at 8 18 54 PM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/471f259d-b6b6-4930-a406-53a2b572661f">

---

After some investigation, we found out that the issue is caused by PR #205, which now try to find staking providers from RPC.

However, not all validators actually support staking. Some of them not even have contract deployed.

---

After the fix, now the near balance will show properly

<img width="662" alt="Screenshot 2024-03-01 at 8 25 06 PM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/ccf52c3c-9422-43ba-95f5-3745aeab6f8a">

---

Staking page will works properly too

<img width="853" alt="Screenshot 2024-03-01 at 8 26 51 PM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/0b6f61af-4422-4f70-818a-6579045e7efd">
