### PR TITLE
fix: domain api nearblocks for likely tokens and likely nfts

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/mainnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.ts
@@ -2,7 +2,7 @@ import * as nearApiJs from 'near-api-js';
 import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
-    ACCOUNT_HELPER_URL: 'https://api3.nearblocks.io/v1/kitwallet',
+    ACCOUNT_HELPER_URL: 'https://api.nearblocks.io/v1/kitwallet',
     ACCOUNT_KITWALLET_HELPER_URL: 'https://api.kitwallet.app',
     ACCOUNT_ID_SUFFIX: 'near',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
@@ -14,10 +14,10 @@ export default {
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     // INDEXER_SERVICE_URL: 'https://api.kitwallet.app',
-    INDEXER_SERVICE_URL: 'https://api3.nearblocks.io/v1/kitwallet',
+    INDEXER_SERVICE_URL: 'https://api.nearblocks.io/v1/kitwallet',
     INDEXER_FASTNEAR_SERVICE_URL: 'https://api.fastnear.com',
     INDEXER_NEARBLOCK_SERVICE_URL: 'https://api.nearblocks.io',
-    INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api3.nearblocks.io',
+    INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api.nearblocks.io',
     LINKDROP_GAS: '100000000000000',
     LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.near',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),


### PR DESCRIPTION
## Issues

The API provided by Nearblocks has been switched to a new subdomain, https://api.nearblocks.io/. However, the wallet is still using https://api3.nearblocks.io/, causing an error when fetching the list of tokens and NFTs for users.

Nearblocks API Documents: https://api.nearblocks.io/api-docs/

## Changes description

Update https://api3.nearblocks.io to https://api/.nearblocks.io in mainnet environment configs.
