### PR TITLE
fix: zero balance account creation failure

### DIFF
--- a/packages/frontend/src/redux/slices/account/createAccountThunks.js
+++ b/packages/frontend/src/redux/slices/account/createAccountThunks.js
@@ -346,7 +346,7 @@ export const initiateSetupForZeroBalanceAccountLedger = createAsyncThunk(
             try {
                 await sendJson(
                     'POST',
-                    `${CONFIG.ACCOUNT_HELPER_URL}/account/ledgerKeyAdded`,
+                    `${CONFIG.ACCOUNT_KITWALLET_HELPER_URL}/account/ledgerKeyAdded`,
                     {
                         accountId: implicitAccountId,
                         publicKey: ledgerPublicKey.toString(),

--- a/packages/frontend/src/redux/slices/account/createAccountThunks.js
+++ b/packages/frontend/src/redux/slices/account/createAccountThunks.js
@@ -307,7 +307,7 @@ export const initiateSetupForZeroBalanceAccountPhrase = createAsyncThunk(
             try {
                 await sendJson(
                     'POST',
-                    `${CONFIG.ACCOUNT_HELPER_URL}/account/seedPhraseAdded`,
+                    `${CONFIG.ACCOUNT_KITWALLET_HELPER_URL}/account/seedPhraseAdded`,
                     {
                         accountId: implicitAccountId,
                         publicKey: recoveryKeyPair.publicKey.toString(),

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -57,9 +57,9 @@ export const WALLET_VERIFY_OWNER_URL = 'verify-owner';
 export const WALLET_SIGN_MESSAGE_URL = 'sign-message';
 
 export const CONTRACT_CREATE_ACCOUNT_URL = `${CONFIG.ACCOUNT_HELPER_URL}/account`;
-export const FUNDED_ACCOUNT_CREATE_URL = `${CONFIG.ACCOUNT_HELPER_URL}/fundedAccount`;
-export const IDENTITY_FUNDED_ACCOUNT_CREATE_URL = `${CONFIG.ACCOUNT_HELPER_URL}/identityFundedAccount`;
-const IDENTITY_VERIFICATION_METHOD_SEND_CODE_URL = `${CONFIG.ACCOUNT_HELPER_URL}/identityVerificationMethod`;
+export const FUNDED_ACCOUNT_CREATE_URL = `${CONFIG.ACCOUNT_KITWALLET_HELPER_URL}/fundedAccount`;
+export const IDENTITY_FUNDED_ACCOUNT_CREATE_URL = `${CONFIG.ACCOUNT_KITWALLET_HELPER_URL}/identityFundedAccount`;
+const IDENTITY_VERIFICATION_METHOD_SEND_CODE_URL = `${CONFIG.ACCOUNT_KITWALLET_HELPER_URL}/identityVerificationMethod`;
 
 export const SHOW_NETWORK_BANNER = !CONFIG.IS_MAINNET || CONFIG.SHOW_PRERELEASE_WARNING;
 export const ENABLE_IDENTITY_VERIFIED_ACCOUNT = true;
@@ -643,7 +643,7 @@ export default class Wallet {
     async checkFundedAccountAvailable() {
         const { available } = await sendJson(
             'GET',
-            CONFIG.ACCOUNT_HELPER_URL + '/checkFundedAccountAvailable'
+            CONFIG.ACCOUNT_KITWALLET_HELPER_URL + '/checkFundedAccountAvailable'
         );
         return available;
     }


### PR DESCRIPTION
Recently we changed kitwallet API to become nearblocks API, however, some of the API won't work under the new API.

We need to change the account creation API back to kitwallet provider