### PR TITLE
fix(staking): was always success and not wait for loading

### DIFF
--- a/packages/frontend/src/components/staking/StakingContainer.js
+++ b/packages/frontend/src/components/staking/StakingContainer.js
@@ -243,12 +243,12 @@ const StakingContainer = ({ history, match }) => {
     const handleAction = async (action, validator, amount) => {
         let id = Mixpanel.get_distinct_id();
         Mixpanel.identify(id);
-        await Mixpanel.withTracking(action.toUpperCase(), async () => {
+        return await Mixpanel.withTracking(action.toUpperCase(), async () => {
             const properValidator =
                 action === 'stake' ? validator : selectedValidator || validator;
 
-            dispatch(handleStakingAction(action, properValidator, amount));
             Mixpanel.people.set({ [`last_${action}_time`]: new Date().toString() });
+            return dispatch(handleStakingAction(action, properValidator, amount));
         });
     };
 

--- a/packages/frontend/src/components/staking/components/StakingAction.js
+++ b/packages/frontend/src/components/staking/components/StakingAction.js
@@ -133,7 +133,10 @@ export default function StakingAction({
             await handleStakingAction(action, validator.accountId, stakeActionAmount);
             setSuccess(true);
             setConfirm(false);
-        } finally {
+            setLoadingStaking(false);
+        } catch (error) {
+            setSuccess(false);
+            setConfirm(false);
             setLoadingStaking(false);
         }
     };


### PR DESCRIPTION
## Issues
Staking always show success page and on ledger it show success first before approve on ledger

## Changes description
allow staking & unstake waiting for result before showing success page

## Tested
stake
unstake
stake with ledger
unstake with ledger