### PR TITLE
import account access key checker

### DIFF
--- a/packages/frontend/src/components/accounts/RecoverAccountPrivateKey.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountPrivateKey.js
@@ -81,7 +81,7 @@ const RecoverAccountPrivateKey = () => {
                 await dispatch(refreshAccount());
             },
             async (e) => {
-                if (e.data?.errorCode === 'noPublicKeyMatch') {
+                if (e.data?.errorCode === 'accountNotExist') {
                     await dispatch(importZeroBalanceAccountPrivateKey(privateKey));
                     dispatch(setZeroBalanceAccountImportMethod('privateKey'));
                     dispatch(clearGlobalAlert());

--- a/packages/frontend/src/components/accounts/RecoverAccountPrivateKey.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountPrivateKey.js
@@ -14,12 +14,18 @@ import {
     redirectToApp,
     refreshAccount,
 } from '../../redux/actions/account';
-import { clearLocalAlert, showCustomAlert } from '../../redux/actions/status';
+import {
+    clearGlobalAlert,
+    clearLocalAlert,
+    showCustomAlert,
+} from '../../redux/actions/status';
 import { selectStatusLocalAlert } from '../../redux/slices/status';
 import classNames from '../../utils/classNames';
 import parseFundingOptions from '../../utils/parseFundingOptions';
 import FormButton from '../common/FormButton';
 import Container from '../common/styled/Container.css';
+import { importZeroBalanceAccountPrivateKey } from '../../redux/slices/importZeroBalanceAccount/importAccountThunks';
+import { selectZeroBalanceAccountImportMethod } from '../../redux/slices/importZeroBalanceAccount';
 
 const StyledContainer = styled(Container)`
     .input {
@@ -73,12 +79,19 @@ const RecoverAccountPrivateKey = () => {
                 await dispatch(refreshAccount());
             },
             async (e) => {
-                showCustomAlert({
-                    success: false,
-                    messageCodeHeader: 'error',
-                    errorMessage: e.message,
-                    messageCode: 'account.recoverAccount.errorGeneral',
-                });
+                if (e.data?.errorCode === 'noPublicKeyMatch') {
+                    await dispatch(importZeroBalanceAccountPrivateKey(privateKey));
+                    dispatch(selectZeroBalanceAccountImportMethod('privateKey'));
+                    dispatch(clearGlobalAlert());
+                    dispatch(redirectToApp());
+                } else {
+                    showCustomAlert({
+                        success: false,
+                        messageCodeHeader: 'error',
+                        errorMessage: e.message,
+                        messageCode: 'account.recoverAccount.errorGeneral',
+                    });
+                }
 
                 throw e;
             },

--- a/packages/frontend/src/components/accounts/RecoverAccountPrivateKey.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountPrivateKey.js
@@ -14,20 +14,12 @@ import {
     redirectToApp,
     refreshAccount,
 } from '../../redux/actions/account';
-import {
-    clearGlobalAlert,
-    clearLocalAlert,
-    showCustomAlert,
-} from '../../redux/actions/status';
-import { actions as importZeroBalanceAccountActions } from '../../redux/slices/importZeroBalanceAccount';
-import { importZeroBalanceAccountPrivateKey } from '../../redux/slices/importZeroBalanceAccount/importAccountThunks';
+import { clearLocalAlert, showCustomAlert } from '../../redux/actions/status';
 import { selectStatusLocalAlert } from '../../redux/slices/status';
 import classNames from '../../utils/classNames';
 import parseFundingOptions from '../../utils/parseFundingOptions';
 import FormButton from '../common/FormButton';
 import Container from '../common/styled/Container.css';
-
-const { setZeroBalanceAccountImportMethod } = importZeroBalanceAccountActions;
 
 const StyledContainer = styled(Container)`
     .input {
@@ -81,12 +73,12 @@ const RecoverAccountPrivateKey = () => {
                 await dispatch(refreshAccount());
             },
             async (e) => {
-                if (e.message.includes('Cannot find matching public key')) {
-                    await dispatch(importZeroBalanceAccountPrivateKey(privateKey));
-                    dispatch(setZeroBalanceAccountImportMethod('privateKey'));
-                    dispatch(clearGlobalAlert());
-                    dispatch(redirectToApp());
-                }
+                showCustomAlert({
+                    success: false,
+                    messageCodeHeader: 'error',
+                    errorMessage: e.message,
+                    messageCode: 'account.recoverAccount.errorGeneral',
+                });
 
                 throw e;
             },

--- a/packages/frontend/src/components/accounts/RecoverAccountPrivateKey.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountPrivateKey.js
@@ -19,13 +19,15 @@ import {
     clearLocalAlert,
     showCustomAlert,
 } from '../../redux/actions/status';
+import { actions as importZeroBalanceAccountActions } from '../../redux/slices/importZeroBalanceAccount';
+import { importZeroBalanceAccountPrivateKey } from '../../redux/slices/importZeroBalanceAccount/importAccountThunks';
 import { selectStatusLocalAlert } from '../../redux/slices/status';
 import classNames from '../../utils/classNames';
 import parseFundingOptions from '../../utils/parseFundingOptions';
 import FormButton from '../common/FormButton';
 import Container from '../common/styled/Container.css';
-import { importZeroBalanceAccountPrivateKey } from '../../redux/slices/importZeroBalanceAccount/importAccountThunks';
-import { selectZeroBalanceAccountImportMethod } from '../../redux/slices/importZeroBalanceAccount';
+
+const { setZeroBalanceAccountImportMethod } = importZeroBalanceAccountActions;
 
 const StyledContainer = styled(Container)`
     .input {
@@ -81,7 +83,7 @@ const RecoverAccountPrivateKey = () => {
             async (e) => {
                 if (e.data?.errorCode === 'noPublicKeyMatch') {
                     await dispatch(importZeroBalanceAccountPrivateKey(privateKey));
-                    dispatch(selectZeroBalanceAccountImportMethod('privateKey'));
+                    dispatch(setZeroBalanceAccountImportMethod('privateKey'));
                     dispatch(clearGlobalAlert());
                     dispatch(redirectToApp());
                 } else {

--- a/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -121,7 +121,7 @@ class RecoverAccountSeedPhrase extends Component {
                 await refreshAccount();
             },
             async (e) => {
-                if (e.data?.errorCode === 'noPublicKeyMatch') {
+                if (e.data?.errorCode === 'accountNotExist') {
                     await importZeroBalanceAccountPhrase(seedPhrase);
                     setZeroBalanceAccountImportMethod('phrase');
                     clearGlobalAlert();

--- a/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -15,11 +15,7 @@ import {
     refreshAccount,
     clearAccountState,
 } from '../../redux/actions/account';
-import {
-    clearLocalAlert,
-    showCustomAlert,
-    clearGlobalAlert,
-} from '../../redux/actions/status';
+import { clearLocalAlert, showCustomAlert } from '../../redux/actions/status';
 import { selectAccountSlice } from '../../redux/slices/account';
 import { actions as importZeroBalanceAccountActions } from '../../redux/slices/importZeroBalanceAccount';
 import { importZeroBalanceAccountPhrase } from '../../redux/slices/importZeroBalanceAccount/importAccountThunks';
@@ -96,8 +92,6 @@ class RecoverAccountSeedPhrase extends Component {
             recoverAccountSeedPhrase,
             refreshAccount,
             showCustomAlert,
-            importZeroBalanceAccountPhrase,
-            setZeroBalanceAccountImportMethod,
         } = this.props;
 
         try {
@@ -121,12 +115,12 @@ class RecoverAccountSeedPhrase extends Component {
                 await refreshAccount();
             },
             async (e) => {
-                if (e.message.includes('Cannot find matching public key')) {
-                    await importZeroBalanceAccountPhrase(seedPhrase);
-                    setZeroBalanceAccountImportMethod('phrase');
-                    clearGlobalAlert();
-                    redirectToApp();
-                }
+                showCustomAlert({
+                    success: false,
+                    messageCodeHeader: 'error',
+                    errorMessage: e.message,
+                    messageCode: e.messageCode,
+                });
 
                 throw e;
             },

--- a/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -15,7 +15,11 @@ import {
     refreshAccount,
     clearAccountState,
 } from '../../redux/actions/account';
-import { clearLocalAlert, showCustomAlert } from '../../redux/actions/status';
+import {
+    clearGlobalAlert,
+    clearLocalAlert,
+    showCustomAlert,
+} from '../../redux/actions/status';
 import { selectAccountSlice } from '../../redux/slices/account';
 import { actions as importZeroBalanceAccountActions } from '../../redux/slices/importZeroBalanceAccount';
 import { importZeroBalanceAccountPhrase } from '../../redux/slices/importZeroBalanceAccount/importAccountThunks';
@@ -115,12 +119,19 @@ class RecoverAccountSeedPhrase extends Component {
                 await refreshAccount();
             },
             async (e) => {
-                showCustomAlert({
-                    success: false,
-                    messageCodeHeader: 'error',
-                    errorMessage: e.message,
-                    messageCode: e.messageCode,
-                });
+                if (e.data?.errorCode === 'noPublicKeyMatch') {
+                    await importZeroBalanceAccountPhrase(seedPhrase);
+                    setZeroBalanceAccountImportMethod('phrase');
+                    clearGlobalAlert();
+                    redirectToApp();
+                } else {
+                    showCustomAlert({
+                        success: false,
+                        messageCodeHeader: 'error',
+                        errorMessage: e.message,
+                        messageCode: e.messageCode,
+                    });
+                }
 
                 throw e;
             },

--- a/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -96,6 +96,8 @@ class RecoverAccountSeedPhrase extends Component {
             recoverAccountSeedPhrase,
             refreshAccount,
             showCustomAlert,
+            importZeroBalanceAccountPhrase,
+            setZeroBalanceAccountImportMethod,
         } = this.props;
 
         try {

--- a/packages/frontend/src/components/common/GlobalAlert.js
+++ b/packages/frontend/src/components/common/GlobalAlert.js
@@ -114,9 +114,10 @@ const Content = styled.div`
 const Icon = styled.div`
     padding-right: 16px;
     flex: 0 0 24px;
+    margin-top: 0.4em;
 
     img {
-        width: 24px;
+        min-width: 24px;
     }
 `;
 

--- a/packages/frontend/src/services/indexer/api.ts
+++ b/packages/frontend/src/services/indexer/api.ts
@@ -8,7 +8,7 @@ import { accountsByPublicKey } from '@mintbase-js/data';
 
 export default {
     listAccountsByPublicKey: (publicKey): Promise<string[]> => {
-        return new Promise(async (masterResolve, masterReject) => {
+        return new Promise(async (masterResolve) => {
             const masterController = new AbortController();
 
             const promises = [
@@ -109,7 +109,7 @@ export default {
             const flattenResults = results.flat();
 
             if (flattenResults.length === 0) {
-                masterReject(new Error('No accounts found'));
+                masterResolve([]);
             }
         });
     },

--- a/packages/frontend/src/translations/locales/en/translation.json
+++ b/packages/frontend/src/translations/locales/en/translation.json
@@ -2015,6 +2015,7 @@
         },
         "recoverAccountSeedPhrase": {
             "errorGeneral": "Failed to recover account.",
+            "keyPairUnmatch": "The imported key does not match the public key.",
             "errorInvalidSeedPhrase": "No accounts were found for this passphrase.",
             "errorNotAbleToImportAccount": "Import of your account failed. Please try again or contact support for assistance.",
             "errorSeedPhraseNotValid": "The provided passphrase is not valid. Please check your passphrase and try again."

--- a/packages/frontend/src/translations/locales/en/translation.json
+++ b/packages/frontend/src/translations/locales/en/translation.json
@@ -2014,6 +2014,7 @@
             "errorPKNotValid": "The provided private key is not valid. Please check your private key and try again."
         },
         "recoverAccountSeedPhrase": {
+            "errorGeneral": "Failed to recover account.",
             "errorInvalidSeedPhrase": "No accounts were found for this passphrase.",
             "errorNotAbleToImportAccount": "Import of your account failed. Please try again or contact support for assistance.",
             "errorSeedPhraseNotValid": "The provided passphrase is not valid. Please check your passphrase and try again."

--- a/packages/frontend/src/translations/locales/en/translation.json
+++ b/packages/frontend/src/translations/locales/en/translation.json
@@ -2015,10 +2015,10 @@
         },
         "recoverAccountSeedPhrase": {
             "errorGeneral": "Failed to recover account.",
-            "keyPairUnmatch": "The imported key does not match the public key.",
             "errorInvalidSeedPhrase": "No accounts were found for this passphrase.",
             "errorNotAbleToImportAccount": "Import of your account failed. Please try again or contact support for assistance.",
-            "errorSeedPhraseNotValid": "The provided passphrase is not valid. Please check your passphrase and try again."
+            "errorSeedPhraseNotValid": "The provided passphrase is not valid. Please check your passphrase and try again.",
+            "keyPairUnmatch": "The imported key does not match the public key."
         },
         "recoveryMethods": {
             "lastMethod": "Cannot delete your last recovery method. Unless you have Ledger enabled, you need to keep at least one recovery method active to ensure recoverability of your account.",

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -32,7 +32,6 @@ import { makeAccountActive, redirectTo, switchAccount } from '../redux/actions/a
 import { actions as ledgerActions } from '../redux/slices/ledger';
 import passwordProtectedWallet from '../redux/slices/passwordProtectedWallet/passwordProtectedWallet';
 import sendJson from '../tmp_fetch_send_json';
-import { showCustomAlert } from '../redux/actions/status';
 
 export const WALLET_CREATE_NEW_ACCOUNT_URL = 'create';
 export const WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS = [
@@ -1579,7 +1578,8 @@ export default class Wallet {
         if (!accountIds.length) {
             throw new WalletError(
                 `Cannot find matching public key: ${publicKey}`,
-                'recoverAccountSeedPhrase.errorInvalidSeedPhrase'
+                'recoverAccountSeedPhrase.errorInvalidSeedPhrase',
+                { errorCode: 'noPublicKeyMatch' }
             );
         }
 
@@ -1704,12 +1704,6 @@ export default class Wallet {
                 );
 
                 throw lastAccount.error;
-            } else if (!accountIdsError.length) {
-                showCustomAlert({
-                    success: false,
-                    messageCodeHeader: 'error',
-                    messageCode: 'walletErrorCodes.recoverAccount.error',
-                });
             } else {
                 throw accountIdsError[accountIdsError.length - 1].error;
             }

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -1561,15 +1561,15 @@ export default class Wallet {
 
         // remove duplicate and non-existing accounts
         const accountsSet = new Set(accountIds);
-        let deletedAccount;
+        let hasDeletedAccount = false;
         for (const accountId of accountsSet) {
             if (!(await this.accountExists(accountId))) {
                 accountsSet.delete(accountId);
-                deletedAccount = accountId;
+                hasDeletedAccount = !!accountId;
             }
         }
         accountIds = [...accountsSet];
-        if (deletedAccount && !accountIds.length) {
+        if (hasDeletedAccount && !accountIds.length) {
             throw new WalletError(
                 `Cannot import account but found deleted account for public key: ${publicKey}`,
                 'recoverAccountSeedPhrase.errorGeneral'

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -1567,7 +1567,6 @@ export default class Wallet {
         let hasDeletedAccount = false;
         for (const accountId of accountsSet) {
             const isAccountExist = await this.accountExists(accountId);
-            console.log({ isAccountExist, accountId });
             if (!isAccountExist) {
                 accountsSet.delete(accountId);
                 hasDeletedAccount = !!accountId;

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -1605,11 +1605,21 @@ export default class Wallet {
                 let recoveryKeyIsFAK = false;
 
                 const accessKeys = await account.getAccessKeys();
-                if (!accessKeys.length && accountIds.length === 1) {
-                    throw new WalletError(
-                        `No access key found for ${accountId}`,
-                        'recoverAccountSeedPhrase.errorGeneral'
-                    );
+                const hasFullAccessKey = accessKeys.some(
+                    (key) => key.access_key.permission === 'FullAccess'
+                );
+
+                if (accountIds.length === 1) {
+                    if (!accessKeys.length || !hasFullAccessKey) {
+                        accountIdsError.push({
+                            accountId,
+                            error: new WalletError(
+                                `No access key found for ${accountId}`,
+                                'recoverAccountSeedPhrase.errorGeneral'
+                            ),
+                        });
+                        return;
+                    }
                 }
 
                 // check if recover access key is FAK and if so add key without 2FA

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -453,7 +453,7 @@ export default class Wallet {
         }
 
         throw new WalletError(
-            'No matching key pair for public key',
+            `No matching key pair for public key ${publicKeyString}`,
             'recoverAccountSeedPhrase.keyPairUnmatch',
             { errorCode: 'keyPairUnmatch' }
         );


### PR DESCRIPTION
## Issues
Deleted private access key account was able imported into wallet, & user cant do any transaction
Most error reported:
Can not sign transactions for account .... on network default, no matching key pair found
It will resolve this issue for new user who import invalid seedphrase with incorrect private key to the wallet, but for existing user will have same behavior no changes & they need to import with valid seedphrase with correct full access key

## Changes description
when import deleted all full access key  / deleted private key will show error

## Preview
<img width="978" alt="Screen Shot 2024-03-14 at 12 14 46" src="https://github.com/mynearwallet/my-near-wallet/assets/22742847/f6d9a350-f5b5-470e-bf72-97079a3cd621">


## Tested
1. import account with deleted full access key, and found on indexer, should show error no matching keypair
2. import account with deleted full access key, and deleted on indexer will imported as implicit account with zero balance, because we cant find the account on indexer with that private key
3. import account with deleted private access key, & have new public key & account found on indexer should not able to import
4. import account with deleted account & found on indexer, should show error, [with error message: Cannot import account but found deleted account for public key]
5. import account with with ledger success
6. import account with seedphrase success, & able todo send transaction
7. create new account, dont fund it, import with that seedphrase, should create implicit account with zero balance