### PR TITLE
Near ICO multisig users fix.

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
@@ -2,7 +2,7 @@ import * as nearApiJs from 'near-api-js';
 import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
-    ACCOUNT_HELPER_URL: 'https://api3.nearblocks.io/v1/kitwallet',
+    ACCOUNT_HELPER_URL: 'https://api.nearblocks.io/v1/kitwallet',
     ACCOUNT_KITWALLET_HELPER_URL: 'https://api.kitwallet.app',
     ACCOUNT_ID_SUFFIX: 'near',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
@@ -14,10 +14,10 @@ export default {
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
     // INDEXER_SERVICE_URL: 'https://api.kitwallet.app',
-    INDEXER_SERVICE_URL: 'https://api3.nearblocks.io/v1/kitwallet',
+    INDEXER_SERVICE_URL: 'https://api.nearblocks.io/v1/kitwallet',
     INDEXER_FASTNEAR_SERVICE_URL: 'https://api.fastnear.com',
     INDEXER_NEARBLOCK_SERVICE_URL: 'https://api.nearblocks.io',
-    INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api3.nearblocks.io',
+    INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api.nearblocks.io',
     LINKDROP_GAS: '100000000000000',
     LOCKUP_ACCOUNT_ID_SUFFIX: 'lockup.near',
     MIN_BALANCE_FOR_GAS: nearApiJs.utils.format.parseNearAmount('0.05'),

--- a/packages/frontend/src/services/indexer/api.ts
+++ b/packages/frontend/src/services/indexer/api.ts
@@ -79,7 +79,7 @@ export default {
                 // ---------------------
                 promises.push(
                     fetch(
-                        `${CONFIG.INDEXER_FASTNEAR_SERVICE_URL}/v0/public_key/${publicKey}`,
+                        `${CONFIG.INDEXER_FASTNEAR_SERVICE_URL}/v0/public_key/${publicKey}/all`,
                         {
                             signal: masterController.signal,
                         }

--- a/packages/frontend/src/utils/moonpay.js
+++ b/packages/frontend/src/utils/moonpay.js
@@ -48,7 +48,7 @@ export const getSignedUrl = async (accountId, redirectUrl) => {
         `&redirectURL=${encodeURIComponent(redirectUrl)}`;
     const { signature } = await sendJson(
         'GET',
-        `${CONFIG.ACCOUNT_HELPER_URL}/moonpay/signURL?url=${encodeURIComponent(
+        `${CONFIG.ACCOUNT_KITWALLET_HELPER_URL}/moonpay/signURL?url=${encodeURIComponent(
             widgetUrl
         )}`
     );

--- a/packages/frontend/src/utils/twoFactor.js
+++ b/packages/frontend/src/utils/twoFactor.js
@@ -19,7 +19,7 @@ export class TwoFactor extends Account2FA {
     constructor(wallet, accountId, has2fa = false) {
         super(wallet.connection, accountId, {
             storage: localStorage,
-            helperUrl: CONFIG.ACCOUNT_HELPER_URL,
+            helperUrl: CONFIG.ACCOUNT_KITWALLET_HELPER_URL,
             getCode: () => store.dispatch(promptTwoFactor(true)).payload.promise,
         });
         this.wallet = wallet;
@@ -138,7 +138,7 @@ export class TwoFactor extends Account2FA {
         }
 
         const account = new Account2FA(connection, accountId, {
-            helperUrl: CONFIG.ACCOUNT_HELPER_URL,
+            helperUrl: CONFIG.ACCOUNT_KITWALLET_HELPER_URL,
         });
 
         return await account.disableWithFAK({

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -56,7 +56,7 @@ export const WALLET_SEND_MONEY_URL = 'send-money';
 export const WALLET_VERIFY_OWNER_URL = 'verify-owner';
 export const WALLET_SIGN_MESSAGE_URL = 'sign-message';
 
-export const CONTRACT_CREATE_ACCOUNT_URL = `${CONFIG.ACCOUNT_HELPER_URL}/account`;
+export const CONTRACT_CREATE_ACCOUNT_URL = `${CONFIG.ACCOUNT_KITWALLET_HELPER_URL}/account`;
 export const FUNDED_ACCOUNT_CREATE_URL = `${CONFIG.ACCOUNT_KITWALLET_HELPER_URL}/fundedAccount`;
 export const IDENTITY_FUNDED_ACCOUNT_CREATE_URL = `${CONFIG.ACCOUNT_KITWALLET_HELPER_URL}/identityFundedAccount`;
 const IDENTITY_VERIFICATION_METHOD_SEND_CODE_URL = `${CONFIG.ACCOUNT_KITWALLET_HELPER_URL}/identityVerificationMethod`;
@@ -1345,7 +1345,8 @@ export default class Wallet {
         };
         await sendJson(
             'POST',
-            CONFIG.ACCOUNT_HELPER_URL + '/account/initializeRecoveryMethodForTempAccount',
+            CONFIG.ACCOUNT_KITWALLET_HELPER_URL +
+                '/account/initializeRecoveryMethodForTempAccount',
             body
         );
         return seedPhrase;
@@ -1362,7 +1363,7 @@ export default class Wallet {
         if (isNew) {
             await sendJson(
                 'POST',
-                CONFIG.ACCOUNT_HELPER_URL +
+                CONFIG.ACCOUNT_KITWALLET_HELPER_URL +
                     '/account/initializeRecoveryMethodForTempAccount',
                 body
             );
@@ -1381,7 +1382,8 @@ export default class Wallet {
         try {
             await sendJson(
                 'POST',
-                CONFIG.ACCOUNT_HELPER_URL + '/account/validateSecurityCodeForTempAccount',
+                CONFIG.ACCOUNT_KITWALLET_HELPER_URL +
+                    '/account/validateSecurityCodeForTempAccount',
                 {
                     accountId: implicitAccountId,
                     method,
@@ -1417,7 +1419,7 @@ export default class Wallet {
             if (isNew) {
                 await sendJson(
                     'POST',
-                    CONFIG.ACCOUNT_HELPER_URL +
+                    CONFIG.ACCOUNT_KITWALLET_HELPER_URL +
                         '/account/validateSecurityCodeForTempAccount',
                     {
                         ...body,


### PR DESCRIPTION
## Description

Thanks to user `elorpar.near` and an anonymous user who contributed a lot of info in debugging on this issue.

Currently, users who get their account from initial coin offering, can't sign any transaction.

----

## Investigation

After some investigation, we believe that PR #211 broke the mechanism.

----

## Changes

Thus, we make the necessary changes back.

----

## Testing

We did create an account and able to replicate the error that user told us, which is "Not found".
<img width="1716" alt="Screenshot 2024-03-13 at 11 56 25 AM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/73b246da-da27-462c-896c-39d567d8c0d2">

However, since the account that i use is created by myself, thus I can't further test it.... I have tried to deployed a multisig contract into my account, but sadly my account is not the real "ICO account"

My fake multisign account will show this error, because it is not the multisig account that near team give to users.
<img width="1631" alt="Screenshot 2024-03-13 at 1 27 05 PM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/74b6020b-0302-43d1-aaa2-f707bf5a1f3e">

----

## User staging testing

Thus, we are now proceed to trying to publish the PR temporarily to a staging site at https://pr-223-staging.mynearwallet.com/, and invite our user that holding the real "ICO account" to test it.

According to elorpar.near, this PR seems to fix the problem, he can sign transaction now.
<img width="715" alt="Screenshot 2024-03-13 at 5 26 10 PM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/2449f25d-0359-4d7c-b006-dfc1c78910d3">

