### PR TITLE
fix(token): fix show all token

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/development.ts
+++ b/packages/frontend/src/config/environmentDefaults/development.ts
@@ -2,7 +2,7 @@ import * as nearApiJs from 'near-api-js';
 import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
-    ACCOUNT_HELPER_URL: 'https://testnet-api.kitwallet.app',
+    ACCOUNT_HELPER_URL: 'https://api-testnet.nearblocks.io/v1/kitwallet',
     ACCOUNT_KITWALLET_HELPER_URL: 'https://testnet-api.kitwallet.app',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
@@ -12,7 +12,7 @@ export default {
     EXPLORER_URL: 'https://testnet.nearblocks.io',
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
-    INDEXER_SERVICE_URL: 'https://testnet-api.kitwallet.app',
+    INDEXER_SERVICE_URL: 'https://api-testnet.nearblocks.io/v1/kitwallet',
     INDEXER_FASTNEAR_SERVICE_URL: 'https://api.fastnear.com',
     INDEXER_NEARBLOCK_SERVICE_URL: 'https://api-testnet.nearblocks.io',
     INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api-testnet.nearblocks.io',

--- a/packages/frontend/src/config/environmentDefaults/testnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet.ts
@@ -2,7 +2,7 @@ import * as nearApiJs from 'near-api-js';
 import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
-    ACCOUNT_HELPER_URL: 'https://testnet-api.kitwallet.app',
+    ACCOUNT_HELPER_URL: 'https://api-testnet.nearblocks.io/v1/kitwallet',
     ACCOUNT_KITWALLET_HELPER_URL: 'https://testnet-api.kitwallet.app',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
@@ -13,7 +13,7 @@ export default {
     EXPLORER_URL: 'https://testnet.nearblocks.io',
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
-    INDEXER_SERVICE_URL: 'https://testnet-api.kitwallet.app',
+    INDEXER_SERVICE_URL: 'https://api-testnet.nearblocks.io/v1/kitwallet',
     INDEXER_FASTNEAR_SERVICE_URL: 'https://api.fastnear.com',
     INDEXER_NEARBLOCK_SERVICE_URL: 'https://api-testnet.nearblocks.io',
     INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api-testnet.nearblocks.io',

--- a/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
@@ -2,7 +2,7 @@ import * as nearApiJs from 'near-api-js';
 import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
-    ACCOUNT_HELPER_URL: 'https://testnet-api.kitwallet.app',
+    ACCOUNT_HELPER_URL: 'https://api-testnet.nearblocks.io/v1/kitwallet',
     ACCOUNT_KITWALLET_HELPER_URL: 'https://testnet-api.kitwallet.app',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
@@ -13,7 +13,7 @@ export default {
     EXPLORER_URL: 'https://testnet.nearblocks.io',
     GLEAP_FRONTEND_API_KEY: 'Pc07nwsDmsVoWYJJj9BgES87xE7RCW74',
     HIDE_SIGN_IN_WITH_LEDGER_ENTER_ACCOUNT_ID_MODAL: false,
-    INDEXER_SERVICE_URL: 'https://testnet-api.kitwallet.app',
+    INDEXER_SERVICE_URL: 'https://api-testnet.nearblocks.io/v1/kitwallet',
     INDEXER_FASTNEAR_SERVICE_URL: 'https://api.fastnear.com',
     INDEXER_NEARBLOCK_SERVICE_URL: 'https://api-testnet.nearblocks.io',
     INDEXER_NEARBLOCK_EXPERIMENTAL_SERVICE_URL: 'https://api-testnet.nearblocks.io',

--- a/packages/frontend/src/redux/slices/tokens/topTokens.json
+++ b/packages/frontend/src/redux/slices/tokens/topTokens.json
@@ -28,5 +28,9 @@
     "3ea8ea4237344c9931214796d9417af1a1180770.factory.bridge.near",
     "e99de844ef3ef72806cf006224ef3b813e82662f.factory.bridge.near",
     "3432b6a60d23ca0dfca7761b7ab56459d9c964d0.factory.bridge.near",
-    "ftv2.nekotoken.near"
+    "ftv2.nekotoken.near",
+    "nearnvidia.near",
+    "blackdragon.tkn.near",
+    "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1",
+    "853d955acef822db058eb8505911ed77f175b99e.factory.bridge.near"
 ]

--- a/packages/frontend/src/services/indexer/api.ts
+++ b/packages/frontend/src/services/indexer/api.ts
@@ -125,16 +125,13 @@ export default {
             })
         );
     },
-    listLikelyTokens: (accountId, timestamp) => {
+    listLikelyTokens: (accountId) => {
         const url = `${CONFIG.INDEXER_SERVICE_URL}/account/${accountId}/likelyTokensFromBlock`;
 
         return sendJson(
             'GET',
             stringifyUrl({
                 url,
-                query: {
-                    fromBlockTimestamp: timestamp,
-                },
             })
         );
     },


### PR DESCRIPTION
## Issues
some token not show on list ex: usdc native, 
when hit indexer with wrong param fromBlockTimestamp from cache, server will not response
now fromBlockTimestamp param no longer needed
