### PR TITLE
refactor: rename "rotate key" to become "use this key"

### DIFF
--- a/packages/frontend/src/components/profile/full_access_key_rotations/FullAccessKeyRotation.js
+++ b/packages/frontend/src/components/profile/full_access_key_rotations/FullAccessKeyRotation.js
@@ -161,31 +161,41 @@ const FullAccessKeyRotation = ({ fullAccessKey }) => {
         const inputKeyPair = nearApiJs.KeyPair.fromString(inputSecretKey);
         const inputPublicKey = inputKeyPair.publicKey.toString();
 
-        if (inputPublicKey === fullAccessKey.public_key) {
-            if (confirmDeAuthorize) {
+        if (confirmDeAuthorize) {
+            if (inputPublicKey === fullAccessKey.public_key) {
                 setInputSeedPhraseError(
                     'fullAccessKeys.deAuthorizeConfirm.sameKeyWarning'
                 );
-            } else if (confirmRotate) {
-                setInputSeedPhraseError(
-                    'fullAccessKeys.deAuthorizeConfirm.sameKeyWarning'
-                );
+                setInputSeedPhraseSuccess('');
+                return;
             }
-            setInputSeedPhraseSuccess('');
+
+            if (
+                fullAccessKeys.filter(
+                    (accessKey) => accessKey.public_key === inputPublicKey
+                ).length === 0
+            ) {
+                setInputSeedPhraseError('fullAccessKeys.warning.invalidKey');
+                setInputSeedPhraseSuccess('');
+                return;
+            }
+
+            setInputSeedPhraseError('');
+            setInputSeedPhraseSuccess(inputPublicKey);
             return;
         }
 
-        if (
-            fullAccessKeys.filter((accessKey) => accessKey.public_key === inputPublicKey)
-                .length === 0
-        ) {
-            setInputSeedPhraseError('fullAccessKeys.warning.invalidKey');
-            setInputSeedPhraseSuccess('');
+        if (confirmRotate) {
+            if (inputPublicKey !== fullAccessKey.public_key) {
+                setInputSeedPhraseError('fullAccessKeys.warning.doesNotMatch');
+                setInputSeedPhraseSuccess('');
+                return;
+            }
+
+            setInputSeedPhraseError('');
+            setInputSeedPhraseSuccess(inputPublicKey);
             return;
         }
-
-        setInputSeedPhraseError('');
-        setInputSeedPhraseSuccess(inputPublicKey);
     }
 
     async function deauthorizeKey() {
@@ -268,19 +278,9 @@ const FullAccessKeyRotation = ({ fullAccessKey }) => {
             const inputKeyPair = nearApiJs.KeyPair.fromString(inputSecretKey);
             const inputPublicKey = inputKeyPair.publicKey.toString();
 
-            if (inputPublicKey === fullAccessKey.public_key) {
+            if (inputPublicKey !== fullAccessKey.public_key) {
                 throw new Error(
-                    'You are already using this key. There is no need to rotate.'
-                );
-            }
-
-            if (
-                fullAccessKeys.filter(
-                    (accessKey) => accessKey.public_key === inputPublicKey
-                ).length === 0
-            ) {
-                throw new Error(
-                    'The key you entered is not a valid recovery key for this account'
+                    'The seed phrase you entered does not match this public key.'
                 );
             }
 
@@ -547,31 +547,34 @@ const FullAccessKeyRotation = ({ fullAccessKey }) => {
                             ) : null}
                         </div>
                         {fullAccessKey.public_key === publicKey ? (
-                            <FormButton
-                                color='gray-blue'
-                                className='small'
-                                onClick={() => {
-                                    setConfirmRotate(true);
-                                }}
-                                disabled={rotating}
-                                sending={rotating}
-                                sendingString='button.rotatingKey'
-                            >
-                                <Translate id='button.rotateKey' />
-                            </FormButton>
+                            <></>
                         ) : (
-                            <FormButton
-                                color='gray-red'
-                                className='small'
-                                onClick={() => {
-                                    setConfirmDeAuthorize(true);
-                                }}
-                                disabled={deAuthorizing}
-                                sending={deAuthorizing}
-                                sendingString='button.deAuthorizing'
-                            >
-                                <Translate id='button.deauthorize' />
-                            </FormButton>
+                            <div className='mt-0'>
+                                <FormButton
+                                    color='gray-blue'
+                                    className='small'
+                                    onClick={() => {
+                                        setConfirmRotate(true);
+                                    }}
+                                    disabled={rotating}
+                                    sending={rotating}
+                                    sendingString='button.rotatingKey'
+                                >
+                                    <Translate id='button.rotateKey' />
+                                </FormButton>{' '}
+                                <FormButton
+                                    color='gray-red'
+                                    className='small'
+                                    onClick={() => {
+                                        setConfirmDeAuthorize(true);
+                                    }}
+                                    disabled={deAuthorizing}
+                                    sending={deAuthorizing}
+                                    sendingString='button.deAuthorizing'
+                                >
+                                    <Translate id='button.deauthorize' />
+                                </FormButton>
+                            </div>
                         )}
                     </div>
                     <div className='key font-monospace mt-4'>

--- a/packages/frontend/src/translations/locales/en/translation.json
+++ b/packages/frontend/src/translations/locales/en/translation.json
@@ -664,7 +664,7 @@
         "useContract": "Use <b>${receiverId}</b> contract on your behalf",
         "viewYourAccountName": "View your Account Name",
         "warning": {
-            "doesNotMatch": "he key you entered is not a valid recovery key for the public key you wanted to use.",
+            "doesNotMatch": "The key you entered is not a valid recovery key for the public key you wanted to use.",
             "invalidFormat": "We cannot detect the key format you entered.",
             "invalidKey": "The key you entered is not a valid recovery key for this account.",
             "invalidSeedPhrase": "The seed phrase you entered is not valid; its checksum is incorrect."

--- a/packages/frontend/src/translations/locales/en/translation.json
+++ b/packages/frontend/src/translations/locales/en/translation.json
@@ -315,7 +315,7 @@
         "resubmit": "Resubmit",
         "retry": "Retry",
         "returnToApp": "Return to App",
-        "rotateKey": "Rotate Key",
+        "rotateKey": "Use this key",
         "rotatingKey": "Rotating Key",
         "saveChanges": "Save Changes",
         "secureMyAccount": "Secure My Account",
@@ -656,14 +656,15 @@
             "inUse": "Currently in use",
             "sameKeyWarning": "You are already using this key. There is no need to rotate.",
             "seedPhrase": "Account seed phrase / private key",
-            "seedPhrasePrompt": "Please enter the seed phrase for the key you want to use.",
-            "title": "Rotate Key"
+            "seedPhrasePrompt": "Please enter the seed phrase of this key.",
+            "title": "Use as Current Key"
         },
         "submitAnyTransaction": "Submit any transaction on your behalf",
         "transaction": "Transaction",
         "useContract": "Use <b>${receiverId}</b> contract on your behalf",
         "viewYourAccountName": "View your Account Name",
         "warning": {
+            "doesNotMatch": "he key you entered is not a valid recovery key for the public key you wanted to use.",
             "invalidFormat": "We cannot detect the key format you entered.",
             "invalidKey": "The key you entered is not a valid recovery key for this account.",
             "invalidSeedPhrase": "The seed phrase you entered is not valid; its checksum is incorrect."


### PR DESCRIPTION
The "Rotate Key" might be not user friendly.

We change it to "Use this key" so user can understand it better.

<img width="685" alt="Screenshot 2024-03-21 at 6 14 35 PM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/50b16945-dbc0-4aa5-8b3d-7981eb72997a">
