### PR TITLE
fix: allow more timeout for rpc-provider.spec.ts

### DIFF
--- a/packages/frontend/src/utils/mnw-api-js/test/rpc-provider.spec.ts
+++ b/packages/frontend/src/utils/mnw-api-js/test/rpc-provider.spec.ts
@@ -8,113 +8,141 @@ async function checkConnection(rpcProvider) {
     expect(result.gas_price).toBeTruthy();
 }
 
-test('passing url should work (deprecated method)', async () => {
-    const rpcProvider = new RpcProvider('https://rpc.mainnet.near.org/');
+test(
+    'passing url should work (deprecated method)',
+    async () => {
+        const rpcProvider = new RpcProvider('https://rpc.mainnet.near.org/');
 
-    await checkConnection(rpcProvider);
-});
+        await checkConnection(rpcProvider);
+    },
+    30 * 1000
+);
 
-test('wrong url should throw error (deprecated method)', async () => {
-    const rpcProvider = new RpcProvider('https://wrong-url.com/');
+test(
+    'wrong url should throw error (deprecated method)',
+    async () => {
+        const rpcProvider = new RpcProvider('https://wrong-url.com/');
 
-    try {
-        const result = await rpcProvider.sendJsonRpc('gas_price', [null]);
+        try {
+            const result = await rpcProvider.sendJsonRpc('gas_price', [null]);
 
-        expect(result).toBeUndefined();
-    } catch (err) {
-        expect(err.type).toBe('RetriesExceeded');
-    }
-});
+            expect(result).toBeUndefined();
+        } catch (err) {
+            expect(err.type).toBe('RetriesExceeded');
+        }
+    },
+    60 * 1000
+);
 
-test('passing ConnectionInfo should work (original method)', async () => {
-    const rpcProvider = new RpcProvider({ url: 'https://rpc.mainnet.near.org/' });
+test(
+    'passing ConnectionInfo should work (original method)',
+    async () => {
+        const rpcProvider = new RpcProvider({ url: 'https://rpc.mainnet.near.org/' });
 
-    await checkConnection(rpcProvider);
-});
+        await checkConnection(rpcProvider);
+    },
+    30 * 1000
+);
 
-test('wrong ConnectionInfo should throw error (original method)', async () => {
-    const rpcProvider = new RpcProvider({ url: 'https://wrong-url.com/' });
+test(
+    'wrong ConnectionInfo should throw error (original method)',
+    async () => {
+        const rpcProvider = new RpcProvider({ url: 'https://wrong-url.com/' });
 
-    try {
-        const result = await rpcProvider.sendJsonRpc('gas_price', [null]);
+        try {
+            const result = await rpcProvider.sendJsonRpc('gas_price', [null]);
 
-        expect(result).toBeUndefined();
-    } catch (err) {
-        expect(err.type).toBe('RetriesExceeded');
-    }
-});
+            expect(result).toBeUndefined();
+        } catch (err) {
+            expect(err.type).toBe('RetriesExceeded');
+        }
+    },
+    60 * 1000
+);
 
-test('wrong RPC details should work as long as there is at least one correct (new method)', async () => {
-    const rpcProvider = new RpcProvider(
-        new RpcRotator([
-            {
-                id: 'custom',
-                data: {
-                    url: 'https://wrong-url.com/',
+test(
+    'wrong RPC details should work as long as there is at least one correct (new method)',
+    async () => {
+        const rpcProvider = new RpcProvider(
+            new RpcRotator([
+                {
+                    id: 'custom',
+                    data: {
+                        url: 'https://wrong-url.com/',
+                    },
                 },
-            },
-            {
-                id: 'custom',
-                data: {
-                    url: 'https://google.com/',
+                {
+                    id: 'custom',
+                    data: {
+                        url: 'https://google.com/',
+                    },
                 },
-            },
-            {
-                id: 'near',
-            },
-        ])
-    );
-
-    await checkConnection(rpcProvider);
-});
-
-test('RPC details should throw error if all of them is invalid (new method)', async () => {
-    const rpcProvider = new RpcProvider(
-        new RpcRotator([
-            {
-                id: 'custom',
-                data: {
-                    url: 'https://wrong-url.com/',
+                {
+                    id: 'near',
                 },
-            },
-            {
-                id: 'custom',
-                data: {
-                    url: 'https://google.com/',
+            ])
+        );
+
+        await checkConnection(rpcProvider);
+    },
+    90 * 1000
+);
+
+test(
+    'RPC details should throw error if all of them is invalid (new method)',
+    async () => {
+        const rpcProvider = new RpcProvider(
+            new RpcRotator([
+                {
+                    id: 'custom',
+                    data: {
+                        url: 'https://wrong-url.com/',
+                    },
                 },
-            },
-        ])
-    );
-
-    try {
-        const result = await rpcProvider.sendJsonRpc('gas_price', [null]);
-
-        expect(result).toBeUndefined();
-    } catch (err) {
-        expect(err.type).toBe('RetriesExceeded');
-    }
-});
-
-test('wrong methods / params will throw error instead of keeping on retry (new method)', async () => {
-    const rpcProvider = new RpcProvider(
-        new RpcRotator([
-            {
-                id: 'near',
-            },
-            {
-                id: 'custom',
-                data: {
-                    url: 'https://wrong-url.com/',
+                {
+                    id: 'custom',
+                    data: {
+                        url: 'https://google.com/',
+                    },
                 },
-            },
-        ])
-    );
+            ])
+        );
 
-    try {
-        const result = await rpcProvider.sendJsonRpc('gas_price', ['wrong params']);
+        try {
+            const result = await rpcProvider.sendJsonRpc('gas_price', [null]);
 
-        expect(result).toBeUndefined();
-    } catch (err) {
-        expect(err.type).not.toBe('RetriesExceeded');
-    }
-});
+            expect(result).toBeUndefined();
+        } catch (err) {
+            expect(err.type).toBe('RetriesExceeded');
+        }
+    },
+    120 * 1000
+);
+
+test(
+    'wrong methods / params will throw error instead of keeping on retry (new method)',
+    async () => {
+        const rpcProvider = new RpcProvider(
+            new RpcRotator([
+                {
+                    id: 'near',
+                },
+                {
+                    id: 'custom',
+                    data: {
+                        url: 'https://wrong-url.com/',
+                    },
+                },
+            ])
+        );
+
+        try {
+            const result = await rpcProvider.sendJsonRpc('gas_price', ['wrong params']);
+
+            expect(result).toBeUndefined();
+        } catch (err) {
+            expect(err.type).not.toBe('RetriesExceeded');
+        }
+    },
+    30 * 1000
+);


### PR DESCRIPTION
Jest test by default only allow 5 seconds timeout.

Due to the test inside `rpc-provider.spec.ts` involving fetching request from network, we decide to allow more timeout.

I am using:
- 30 seconds timeout for test that expected to call a valid url and get response soon
- 60 seconds timeout for test that expected to call a wrong url
- More time for test that calls two or more url, by adding up 30 seconds for each valid url, and 60 seconds for each wrong url