### PR TITLE
fix(nft): get account nfts from multiple indexer

### DIFF
--- a/packages/frontend/src/redux/slices/nft/index.js
+++ b/packages/frontend/src/redux/slices/nft/index.js
@@ -8,9 +8,9 @@ import NonFungibleTokens from '../../../services/NonFungibleTokens';
 import handleAsyncThunkStatus from '../../reducerStatus/handleAsyncThunkStatus';
 import initialStatusState from '../../reducerStatus/initialState/initialStatusState';
 import { createParameterSelector } from '../../selectors/topLevel';
+import { coreIndexerAdapter } from '../../../services/coreIndexer/CoreIndexerAdapter';
 
-const { getLikelyTokenContracts, getMetadata, getToken, getTokens, getNumberOfTokens } =
-    NonFungibleTokens;
+const { getMetadata, getToken, getTokens, getNumberOfTokens } = NonFungibleTokens;
 
 const SLICE_NAME = 'NFT';
 const ENABLE_DEBUG = false;
@@ -167,7 +167,7 @@ const fetchNFTs = createAsyncThunk(
 
         const { dispatch, getState } = thunkAPI;
 
-        const likelyContracts = await getLikelyTokenContracts(accountId);
+        const likelyContracts = await coreIndexerAdapter.getAccountNfts(accountId);
         debugLog({ likelyContracts });
 
         await Promise.all(

--- a/packages/frontend/src/services/coreIndexer/CoreIndexerAdapter.ts
+++ b/packages/frontend/src/services/coreIndexer/CoreIndexerAdapter.ts
@@ -140,6 +140,20 @@ export class CoreIndexerAdapter {
             return [];
         });
     }
+
+    async getAccountNfts(accountId): Promise<string[]> {
+        return await Promise.any(
+            this.indexersInQueue
+                .filter((indexer) =>
+                    indexer.methodsSupported.includes(
+                        E_CoreIndexerAvailableMethods.getAccountNfts
+                    )
+                )
+                .map((indexer) => indexer.getAccountNfts(accountId))
+        ).catch(() => {
+            return [];
+        });
+    }
 }
 
 export const coreIndexerAdapter = CoreIndexerAdapter.getInstance(

--- a/packages/frontend/src/services/coreIndexer/indexers/AbstractCoreIndexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/AbstractCoreIndexer.ts
@@ -20,6 +20,7 @@ export abstract class AbstractCoreIndexer {
     abstract getAccountFtList(accountId: string): Promise<string[]>;
     abstract getAccountValidatorList(accountId: string): Promise<string[]>;
     abstract getValidatorList(): Promise<string[]>;
+    abstract getAccountNfts(accountId: string): Promise<string[]>;
 }
 
 export enum E_CoreIndexerAvailableMethods {
@@ -27,4 +28,5 @@ export enum E_CoreIndexerAvailableMethods {
     getAccountFtList = 'getAccountFtList',
     getAccountValidatorList = 'getAccountValidatorList',
     getValidatorList = 'getValidatorList',
+    getAccountNfts = 'getAccountNfts',
 }

--- a/packages/frontend/src/services/coreIndexer/indexers/FastNearIndexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/FastNearIndexer.ts
@@ -11,6 +11,8 @@ export class FastNearIndexer extends AbstractCoreIndexer {
     methodsSupported = [
         E_CoreIndexerAvailableMethods.getAccountIdListFromPublicKey,
         E_CoreIndexerAvailableMethods.getAccountFtList,
+        E_CoreIndexerAvailableMethods.getAccountValidatorList,
+        E_CoreIndexerAvailableMethods.getAccountNfts,
     ];
 
     protected getBaseUrl(): string {
@@ -43,12 +45,22 @@ export class FastNearIndexer extends AbstractCoreIndexer {
         }
     }
 
-    async getAccountValidatorList(): Promise<string[]> {
-        return [];
+    async getAccountValidatorList(accountId: string): Promise<string[]> {
+        const result = await fetch(
+            `${this.getBaseUrl()}/account/${accountId}/staking`
+        ).then((r) => r.json());
+        return result.contract_ids || [];
     }
 
     async getValidatorList(): Promise<string[]> {
         return [];
+    }
+
+    async getAccountNfts(accountId: string): Promise<string[]> {
+        const result = await fetch(`${this.getBaseUrl()}/account/${accountId}/nft`).then(
+            (r) => r.json()
+        );
+        return result.contract_ids || [];
     }
 }
 

--- a/packages/frontend/src/services/coreIndexer/indexers/MintbaseIndexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/MintbaseIndexer.ts
@@ -40,4 +40,8 @@ export class MintbaseIndexer extends AbstractCoreIndexer {
     async getValidatorList(): Promise<string[]> {
         return [];
     }
+
+    async getAccountNfts(): Promise<string[]> {
+        return [];
+    }
 }

--- a/packages/frontend/src/services/coreIndexer/indexers/NearblocksV1Indexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/NearblocksV1Indexer.ts
@@ -71,6 +71,10 @@ export class NearblocksV1Indexer extends AbstractCoreIndexer {
             },
         }).then((r) => r.json());
     }
+
+    async getAccountNfts(): Promise<string[]> {
+        return [];
+    }
 }
 
 interface I_getAccountIdListFromPublicKey_Output {

--- a/packages/frontend/src/services/coreIndexer/indexers/NearblocksV3Indexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/NearblocksV3Indexer.ts
@@ -76,7 +76,7 @@ export class NearblocksV3Indexer extends AbstractCoreIndexer {
     }
 
     async getAccountNfts(accountId: string): Promise<string[]> {
-        return fetch(
+        const result = await fetch(
             `${this.getBaseUrl()}/kitwallet/account/${accountId}/likelyNFTsFromBlock`,
             {
                 headers: {
@@ -84,6 +84,7 @@ export class NearblocksV3Indexer extends AbstractCoreIndexer {
                 },
             }
         ).then((r) => r.json());
+        return result?.list || [];
     }
 }
 

--- a/packages/frontend/src/services/coreIndexer/indexers/NearblocksV3Indexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/NearblocksV3Indexer.ts
@@ -14,6 +14,7 @@ export class NearblocksV3Indexer extends AbstractCoreIndexer {
         E_CoreIndexerAvailableMethods.getAccountFtList,
         E_CoreIndexerAvailableMethods.getAccountValidatorList,
         E_CoreIndexerAvailableMethods.getValidatorList,
+        E_CoreIndexerAvailableMethods.getAccountNfts,
     ];
 
     protected getBaseUrl(): string {
@@ -72,6 +73,17 @@ export class NearblocksV3Indexer extends AbstractCoreIndexer {
                 ...CUSTOM_REQUEST_HEADERS,
             },
         }).then((r) => r.json());
+    }
+
+    async getAccountNfts(accountId: string): Promise<string[]> {
+        return fetch(
+            `${this.getBaseUrl()}/kitwallet/account/${accountId}/likelyNFTsFromBlock`,
+            {
+                headers: {
+                    ...CUSTOM_REQUEST_HEADERS,
+                },
+            }
+        ).then((r) => r.json());
     }
 }
 


### PR DESCRIPTION
## Issues
nft page not showing if nearblocks down 

## Changes description
add multiple indexer for nft list, if one of indexer down other indexer still can show the nft list
