### PR TITLE
🚸(ux):  press 'Enter' to submit the password

### DIFF
--- a/packages/frontend/src/components/accounts/password_encryption/UnlockWalletPage.tsx
+++ b/packages/frontend/src/components/accounts/password_encryption/UnlockWalletPage.tsx
@@ -1,9 +1,9 @@
 import React, { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Translate } from 'react-localize-redux';
-
 import Input from './SetPassword/ui/Input';
 import { Submit } from './SetPasswordForm/ui';
+
 import { currentTargetValue } from '../../../shared/lib/forms/selectors';
 import { wallet } from '../../../utils/wallet';
 import FormButton from '../../common/FormButton';
@@ -39,6 +39,12 @@ export const UnlockWalletPage: FC<UnlockWalletPageProps> = ({
         setPassword(value);
     };
 
+    const handleKeyUp = (e) => {
+        if (e && e.key === 'Enter' && password.length) {
+            unlockHandler();
+        }
+    };
+
     return (
         <Container className='small-centered border'>
             <div>
@@ -56,6 +62,7 @@ export const UnlockWalletPage: FC<UnlockWalletPageProps> = ({
                     data-test-id='password'
                     value={password ?? ''}
                     onChange={currentTargetValue(handleChangePassword)}
+                    onKeyUpCapture={handleKeyUp}
                     error={errorMessage}
                 />
 


### PR DESCRIPTION
## Issues

I can't snipe fast enough :(

## Changes description

Made the WalletUnlock page trigger the unlock when the Enter key is pressed, behaving more like a usual form.
I've made sure to only add this to the WalletUnlock page so people don' trigger sending a transaction by mistake but can still unlock their wallets just a wee bit faster :)

When me and my Degen friends play on NEAR we like to stay as native as possible in wallet solutions  💖

Please do let me know if I should've done this any other way since it's the first time I've seen React.
