### PR TITLE
fix(dapps): login ledger

### DIFF
--- a/packages/frontend/src/components/login/v2/ConfirmLoginWrapper.js
+++ b/packages/frontend/src/components/login/v2/ConfirmLoginWrapper.js
@@ -34,7 +34,11 @@ export default ({
             publicKey={publicKey}
             contractId={contractId}
             onClickCancel={onClickCancel}
-            onClickConnect={Mixpanel.withTracking('LOGIN', () => dispatch(allowLogin()))}
+            onClickConnect={() => {
+                return Mixpanel.withTracking('LOGIN', () => {
+                    return dispatch(allowLogin());
+                });
+            }}
             contractIdUrl={contractIdUrl}
             successUrlIsValid={successUrlIsValid}
             privateShardInfo={privateShardInfo}


### PR DESCRIPTION
## Issues
login dapps with ledger sometimes doesnt works & it trigger not by button

on login dapps page, the function triggers on page visit, it is not intended, should be triggered by a button click.
this is why previously users should revisit the page multiple times and sometimes it can login to dapps
solution:
wrap the trigger in a function so it only triggered by a button click

tested
-login with ledger
-login without ledger