### PR TITLE
feat(token): remove coingecko no longer free support and use reffinan…

### DIFF
--- a/packages/frontend/src/components/wallet/Wallet.js
+++ b/packages/frontend/src/components/wallet/Wallet.js
@@ -496,9 +496,6 @@ const FungibleTokens = ({
                         currentLanguage={currentLanguage}
                         showFiatPrice
                     />
-                    <div className='coingecko'>
-                        <Translate id='poweredByCoinGecko' />
-                    </div>
                 </>
             )}
         </>

--- a/packages/frontend/src/redux/slices/tokenFiatValues/index.js
+++ b/packages/frontend/src/redux/slices/tokenFiatValues/index.js
@@ -23,7 +23,7 @@ const fetchTokenFiatValues = createAsyncThunk(
     `${SLICE_NAME}/fetchTokenFiatValues`,
     async (_, { dispatch, getState }) => {
         return Promise.allSettled([
-            dispatch(fetchCoinGeckoFiatValues(['near', 'usn', 'jumbo-exchange'])),
+            // dispatch(fetchCoinGeckoFiatValues(['near', 'usn', 'jumbo-exchange'])),
             dispatch(fetchRefFinanceFiatValues()),
         ]);
     }


### PR DESCRIPTION
## Issues
CoinGecko no longer supports free pricing with the current MNW usage

## Changes description
Remove CoinGecko and keep the Ref.Finance pricing