### PR TITLE
fix(tokens): should show tokens fiat value with many decimals

### DIFF
--- a/packages/frontend/src/components/common/token/TokenBox.js
+++ b/packages/frontend/src/components/common/token/TokenBox.js
@@ -157,7 +157,7 @@ const Title = ({ content, title }) => {
 };
 
 const SubTitle = ({ showFiatPrice, price, currentLanguage, name = '-' }) => {
-    const fiatDecimals = 2;
+    const fiatDecimals = 15;
 
     return (
         <span className='subTitle'>
@@ -166,7 +166,7 @@ const SubTitle = ({ showFiatPrice, price, currentLanguage, name = '-' }) => {
                     <>
                         $
                         {new Intl.NumberFormat(`${currentLanguage}`, {
-                            minimumFractionDigits: fiatDecimals,
+                            minimumFractionDigits: 0,
                             maximumFractionDigits: fiatDecimals,
                         }).format(price)}
                     </>

--- a/packages/frontend/src/utils/fiatValueManager.js
+++ b/packages/frontend/src/utils/fiatValueManager.js
@@ -105,7 +105,7 @@ export default class FiatValueManager {
             return {
                 ...acc,
                 [curr]: {
-                    usd: +Number(prices[curr]?.price).toFixed(2) || null,
+                    usd: +Number(prices[curr]?.price) || null,
                     last_updated_at,
                 },
             };


### PR DESCRIPTION
## Issues
Some token prices with a lot of decimals not showing example Blackdragon

## Changes
Show token prices and the fiat value owned by user


Before:
<img width="657" alt="Screenshot 2024-04-29 at 21 35 48" src="https://github.com/mynearwallet/my-near-wallet/assets/22742847/3e40e051-acad-4e14-93a7-742adb968ba0">


After:
<img width="657" alt="Screenshot 2024-04-29 at 21 31 10" src="https://github.com/mynearwallet/my-near-wallet/assets/22742847/61d1819d-5c40-4c21-8762-6469556ef08d">