### PR TITLE
fix: pr222 broken multisig account login

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/mainnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.ts
@@ -37,6 +37,8 @@ export default {
         '8DKTSceSbxVgh4ANXwqmRqGyPWCuZAR1fCqGPXUjD5nZ',
         // https://github.com/near/core-contracts/blob/f93c146d87a779a2063a30d2c1567701306fcae4/multisig/res/multisig.wasm
         '55E7imniT2uuYrECn17qJAk9fLcwQW4ftNSwmCJL5Di',
+        // unknown
+        'HRP7Qf2HDaXTD8EWs7G8siNNGxWWBCe1JaDxcM2cJmQR',
     ],
     MULTISIG_MIN_AMOUNT: '4',
     NETWORK_ID: 'default',

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
@@ -37,6 +37,8 @@ export default {
         '8DKTSceSbxVgh4ANXwqmRqGyPWCuZAR1fCqGPXUjD5nZ',
         // https://github.com/near/core-contracts/blob/f93c146d87a779a2063a30d2c1567701306fcae4/multisig/res/multisig.wasm
         '55E7imniT2uuYrECn17qJAk9fLcwQW4ftNSwmCJL5Di',
+        // unknown
+        'HRP7Qf2HDaXTD8EWs7G8siNNGxWWBCe1JaDxcM2cJmQR',
     ],
     MULTISIG_MIN_AMOUNT: '4',
     NETWORK_ID: 'default',

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -1668,11 +1668,13 @@ export default class Wallet {
                     (key) => key.access_key.permission === 'FullAccess'
                 );
 
+                const has2faEnabled = await TwoFactor.has2faEnabled(account);
+
                 const hasMatchedPublicKey = accessKeys.some(
                     ({ public_key }) => public_key === publicKey
                 );
 
-                if (!accessKeys.length || !hasFullAccessKey) {
+                if (!accessKeys.length || !(has2faEnabled || hasFullAccessKey)) {
                     accountIdsError.push({
                         accountId,
                         error: new WalletError(
@@ -1697,7 +1699,7 @@ export default class Wallet {
                 }
 
                 // check if recover access key is FAK and if so add key without 2FA
-                if (await TwoFactor.has2faEnabled(account)) {
+                if (has2faEnabled) {
                     recoveryKeyIsFAK = accessKeys.find(
                         ({ public_key, access_key }) =>
                             public_key === publicKey &&


### PR DESCRIPTION
## Description

The PR222 introduces a check to ensure that full access keys are present while importing an account. However, not all valid imports necessarily include full access keys in their account configuration.

Certain multisig accounts, like multisig.pierre-dev.near, do not possess full access keys but are still valid for import. These accounts rely on limited access keys for their functionality and should be allowed to be imported.

## Before
Screenshot below shows that before the fix, account `multisig.pierre-dev.near` can't be imported.
<img width="1728" alt="Screenshot 2024-05-01 at 11 45 13 AM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/becdefcf-9e20-4059-9c5e-4067ede11065">

## After
Screenshot below shows that after the fix, account `multisig.pierre-dev.near` can be imported successfully.
<img width="1721" alt="Screenshot 2024-05-01 at 11 56 55 AM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/a0a8084c-9dd9-41e3-9eb4-e1b4f74132b6">

