### PR TITLE
Steve/fix lockup for local development

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -15,7 +15,7 @@
         "bundle": "cross-env NODE_ENV=production node ci/runBundler.js",
         "check": "tsc --noEmit",
         "dev": "yarn && cross-env NEAR_WALLET_ENV=testnet REACT_APP_USE_TESTINGLOCKUP=true yarn start",
-        "dev:mainnet": "yarn && cross-env NEAR_WALLET_ENV=mainnet REACT_APP_USE_TESTINGLOCKUP=true yarn start:mainnet",
+        "dev:mainnet": "yarn && cross-env NEAR_WALLET_ENV=mainnet yarn start:mainnet",
         "sentry": "node ci/sentry-send-release.js",
         "test": "jest",
         "fix": "eslint --ext .js --ext .jsx . --fix",

--- a/packages/frontend/src/redux/actions/staking.js
+++ b/packages/frontend/src/redux/actions/staking.js
@@ -491,12 +491,7 @@ export const { staking } = createActions({
         UPDATE_CURRENT: null,
         GET_LOCKUP: [
             async ({ accountId }) => {
-                let lockupId;
-                if (CONFIG.REACT_APP_USE_TESTINGLOCKUP && accountId.length < 64) {
-                    lockupId = `testinglockup.${accountId}`;
-                } else {
-                    lockupId = getLockupAccountId(accountId);
-                }
+                const lockupId = getLockupAccountId(accountId);
 
                 let contract;
                 try {


### PR DESCRIPTION
## Description

This PR shouldn't have any impact on the app. It only fix a bug for local development

The `REACT_APP_USE_TESTINGLOCKUP` environment shouldn't be set inside the `dev:mainnet` script, because it will cause the lockup address calculation to become wrong.

## Refactoring

The logic of this code block is already fully covered inside the `getLockupAccountId` function itself.

To make sure the code didn't repeat itself, it is being refactored.

```javascript
if (CONFIG.REACT_APP_USE_TESTINGLOCKUP && accountId.length < 64) {
    lockupId = `testinglockup.${accountId}`;
} else {
    lockupId = getLockupAccountId(accountId);
}
```