### PR TITLE
fix(tokens): near token balance should load faster

### DIFF
--- a/packages/frontend/src/redux/slices/tokens/index.js
+++ b/packages/frontend/src/redux/slices/tokens/index.js
@@ -320,11 +320,6 @@ export const selectAllowedTokens = createSelector(
         selectNEARAsTokenWithMetadata,
     ],
     (tokensFiatData, tokensWithBalance, setOfBlacklistedNames, nearConfig) => {
-        const nearConfigWithName = {
-            ...nearConfig,
-            contractName: CONFIG.NEAR_ID,
-        };
-
         const tokenList = Object.values(tokensWithBalance).map((tokenData) => ({
             ...tokenData,
             fiatValueMetadata: tokensFiatData[tokenData.contractName] || {},
@@ -346,6 +341,10 @@ export const selectAllowedTokens = createSelector(
             return true;
         });
 
+        const nearConfigWithName = {
+            ...nearConfig,
+            contractName: CONFIG.NEAR_ID,
+        };
         if (![...setOfBlacklistedNames].length) {
             return [nearConfigWithName, ...safeTokenList];
         }

--- a/packages/frontend/src/routes/WalletWrapper.js
+++ b/packages/frontend/src/routes/WalletWrapper.js
@@ -2,7 +2,6 @@ import React, { useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { Wallet } from '../components/wallet/Wallet';
-import useSortedTokens from '../hooks/useSortedTokens';
 import { Mixpanel } from '../mixpanel/index';
 import {
     selectAccountId,
@@ -31,7 +30,6 @@ import {
     actions as recoveryMethodsActions,
     selectRecoveryMethodsByAccountId,
 } from '../redux/slices/recoveryMethods';
-import { selectTokensLoading, selectAllowedTokens } from '../redux/slices/tokens';
 
 const { fetchNFTs } = nftActions;
 const { setLinkdropAmount } = linkdropActions;
@@ -50,9 +48,6 @@ const WalletWrapper = ({ tab, setTab }) => {
     const zeroBalanceAccountImportMethod = useSelector(
         selectZeroBalanceAccountImportMethod
     );
-    const tokensLoading = useSelector((state) =>
-        selectTokensLoading(state, { accountId })
-    );
     const availableAccounts = useSelector(selectAvailableAccounts);
     const sortedNFTs = useSelector((state) =>
         selectTokensWithMetadataForAccountId(state, { accountId })
@@ -60,8 +55,6 @@ const WalletWrapper = ({ tab, setTab }) => {
     const userRecoveryMethods = useSelector((state) =>
         selectRecoveryMethodsByAccountId(state, { accountId })
     );
-    const allowedTokens = useSelector(selectAllowedTokens);
-    const sortedTokens = useSortedTokens(allowedTokens);
 
     useEffect(() => {
         if (accountId) {
@@ -87,8 +80,6 @@ const WalletWrapper = ({ tab, setTab }) => {
             createFromImplicitSuccess={createFromImplicitSuccess}
             createCustomName={createCustomName}
             zeroBalanceAccountImportMethod={zeroBalanceAccountImportMethod}
-            fungibleTokensList={sortedTokens}
-            tokensLoading={tokensLoading}
             availableAccounts={availableAccounts}
             sortedNFTs={sortedNFTs}
             handleCloseLinkdropModal={useCallback(() => {


### PR DESCRIPTION
## Issues
Load near price loaded slower than the rpc call, for example near price need 5s to loaded on UI while rpc only take around 1s
findings: function loadAccount initial state when load token is return empty balance

## Changes:
Get account balance on initial account state
the result loading near token balance is faster

Tested:
- implicit account zero balance
- regular named account with ft tokens