### PR TITLE
fix: storage cost calculation

### DIFF
--- a/packages/frontend/src/utils/accountsLogic/withAdjustedStorageCost.ts
+++ b/packages/frontend/src/utils/accountsLogic/withAdjustedStorageCost.ts
@@ -1,0 +1,30 @@
+import * as nearApiJs from 'near-api-js';
+import BN from 'bn.js';
+
+type NearApiJsAccountConstructor = new (...args: any[]) => nearApiJs.Account;
+
+export function withAdjustedStorageCost<
+    AccountConstructor extends NearApiJsAccountConstructor
+>(Account: AccountConstructor) {
+    return class AccountWithAdjustedStorageCost extends Account {
+        async getAccountBalance(
+            ...args: Parameters<nearApiJs.Account['getAccountBalance']>
+        ): ReturnType<nearApiJs.Account['getAccountBalance']> {
+            const originalBalance = await super.getAccountBalance(...args);
+
+            const totalBalance = new BN(originalBalance.total);
+            const stateStaked = new BN(originalBalance.stateStaked)
+                .mul(new BN(1024))
+                .div(new BN(1000));
+            const staked = new BN(originalBalance.staked);
+            const availableBalance = totalBalance.sub(BN.max(staked, stateStaked));
+
+            return {
+                total: totalBalance.toString(),
+                stateStaked: stateStaked.toString(),
+                staked: staked.toString(),
+                available: availableBalance.toString(),
+            };
+        }
+    };
+}

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -33,6 +33,7 @@ import { makeAccountActive, redirectTo, switchAccount } from '../redux/actions/a
 import { actions as ledgerActions } from '../redux/slices/ledger';
 import passwordProtectedWallet from '../redux/slices/passwordProtectedWallet/passwordProtectedWallet';
 import sendJson from '../tmp_fetch_send_json';
+import { withAdjustedStorageCost } from './accountsLogic/withAdjustedStorageCost';
 
 export const WALLET_CREATE_NEW_ACCOUNT_URL = 'create';
 export const WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS = [
@@ -1253,10 +1254,13 @@ export default class Wallet {
     }
 
     async getAccount(accountId, limitedAccountData = false) {
-        let account = new nearApiJs.Account(this.connection, accountId);
+        const AccountWithAdjustedStorageCost = withAdjustedStorageCost(nearApiJs.Account);
+        let account = new AccountWithAdjustedStorageCost(this.connection, accountId);
+
+        const TwoFactorWithAdjustedStorageCost = withAdjustedStorageCost(TwoFactor);
         const has2fa = await TwoFactor.has2faEnabled(account);
         if (has2fa) {
-            account = new TwoFactor(this, accountId, has2fa);
+            account = new TwoFactorWithAdjustedStorageCost(this, accountId, has2fa);
         }
 
         // TODO: Check if lockup needed somehow? Should be changed to async? Should just check in wrapper?


### PR DESCRIPTION
## Issues

Account with large amount of storage staked (as example, those account with contract deployed, such as multisig), when trying to send near, and press "max", they will end up have insufficient amount of near to support storage cost.

This ends up wasting user's gas fee and they will fail repeatedly again and again unless they choose to send a smaller amount of near manually.

## Changes description

I hijacked the `getAccountBalance` from `near-api-js` `Account`, increasing the storage staking cost by 2.4%.

The reason of why the increment is 2.4% is because from the response of RPC providers, it seems like the shortage is around 2.1%

I am making a smart guess that maybe the calculation of "binary thousands" and "digital thousands", i.e. 1000 vs 1024 is causing the problem. We are expressing thousands as 1000 in digital world, but in binary, for computation effectiveness, we usually divide thousands by 1024. Thus, maybe the real storage is 2.4% more. (similar to why a 100 TB hard drive will end up showing itself as 90++ TB in the computer)

## Error Demo (Before fix)

<img width="1149" alt="Screenshot 2024-05-03 at 7 17 43 AM" src="https://github.com/mynearwallet/my-near-wallet/assets/125173477/ad39d5bf-57fe-467b-b3e8-418108f78a35">

## After fix

We preserved 2.4% more Near for storage cost, which prevents user from exceeding limit when they press on "use max"
