### PR TITLE
feat(transaction-history): ft transfer UI

### DIFF
--- a/packages/frontend/src/redux/slices/transactionHistory/transactionPattern.tsx
+++ b/packages/frontend/src/redux/slices/transactionHistory/transactionPattern.tsx
@@ -151,7 +151,10 @@ class TransferPattern implements TxPattern {
 class TransferFtPattern implements TxPattern {
     match(data: TxData): boolean {
         const methodName = txUtils.getMethodName(data);
-        return methodName === TxMethodName.ft_transfer;
+        return (
+            methodName === TxMethodName.ft_transfer ||
+            methodName === TxMethodName.ft_transfer_call
+        );
     }
 
     display(data: TxData, accountId: string): TransactionItemComponent {
@@ -810,10 +813,10 @@ export class TxDefaultPattern {
 export const txPatterns: TxPattern[] = [
     new MultiActionsPattern(),
     new TransferPattern(),
-    new TransferFtPattern(),
     new DeployPattern(),
     new CreateAccountPattern(),
     new SwapPattern(),
+    new TransferFtPattern(),
     new NftPattern(),
     new MintPattern(),
     new FtMintPattern(),


### PR DESCRIPTION
Improve transaction history UI for ft_transfer_call should show as transfer transaction

<img width="1037" alt="Screenshot 2024-05-15 at 10 05 30" src="https://github.com/mynearwallet/my-near-wallet/assets/22742847/9b3b3e6c-910c-45c4-a99c-24b868903579">
