### PR TITLE
fix nft url

### DIFF
--- a/packages/frontend/src/services/NonFungibleTokens.js
+++ b/packages/frontend/src/services/NonFungibleTokens.js
@@ -123,6 +123,9 @@ export default class NonFungibleTokens {
         }
 
         if (base_uri) {
+            if (base_uri.endsWith('/')) {
+                return `${base_uri.slice(0, -1)}/${media}`;
+            }
             return `${base_uri}/${media}`;
         }
 

--- a/packages/frontend/src/utils/mnw-api-js/test/rpc-provider.spec.ts
+++ b/packages/frontend/src/utils/mnw-api-js/test/rpc-provider.spec.ts
@@ -15,7 +15,7 @@ test(
 
         await checkConnection(rpcProvider);
     },
-    30 * 1000
+    60 * 1000
 );
 
 test(


### PR DESCRIPTION
## Issues
nft url have double slash causing image not loaded
example url
https://bafybeicoyahgprpxedl5iszszm474xy6verklojpafd7tmp5tibh3yoc3i.ipfs.dweb.link//1264.png

solution: remove slash at the end of nft base uri