### PR TITLE
fix(account): remove mnemonic bip39 validation on import account

### DIFF
--- a/packages/frontend/src/utils/isValidSeedPhrase.js
+++ b/packages/frontend/src/utils/isValidSeedPhrase.js
@@ -1,17 +1,7 @@
-import bip39 from 'bip39-light';
-
 export default (seedPhrase) => {
     if (seedPhrase.trim().split(/\s+/g).length < 12) {
         throw new Error('Provided seed phrase must be at least 12 words long');
     }
 
-    const isValidSeedPhrase = bip39.validateMnemonic(seedPhrase.trim());
-
-    if (!isValidSeedPhrase) {
-        throw new Error(
-            'Provided seed phrase is not valid according to bip39-light standard'
-        );
-    }
-
-    return isValidSeedPhrase;
+    return true;
 };


### PR DESCRIPTION
## Issues
some accounts cannot imported with a valid bip39 seed phrase, but it is a valid normal near account

solution: allow any seedphrase to be imported with valid words length