### PR TITLE
feat(tx-interpret): sign transaction interpretation

### DIFF
--- a/packages/frontend/src/components/common/image/ImageWithLoading.tsx
+++ b/packages/frontend/src/components/common/image/ImageWithLoading.tsx
@@ -31,8 +31,8 @@ const ImageWithLoading = ({
 }: {
     skip?: boolean;
     loadImageTimeout?: number;
-    style?: HTMLStyleElement;
-} & Partial<HTMLImageElement>) => {
+    style?: React.CSSProperties;
+} & Omit<Partial<HTMLImageElement>, 'style'>) => {
     const [isErrorImage, setIsErrorImage] = useState(false);
     const { isLoaded, isError } = useImageLoading({
         imageUrl: src,

--- a/packages/frontend/src/components/sign/v2/SignTransaction.js
+++ b/packages/frontend/src/components/sign/v2/SignTransaction.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import Balance from '../../common/balance/Balance';
 import Tooltip from '../../common/Tooltip';
+import TransactionInterpretationItem from './TransactionInterpretationItem';
 
 const StyledContainer = styled.div`
     display: flex;
@@ -93,6 +94,33 @@ const StyledContainer = styled.div`
             }
         }
     }
+    .tx-card {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        width: 100%;
+    }
+    .tx-card__icon {
+        align-self: center;
+        display: flex;
+        margin-right: 0.7em;
+        max-width: 34px;
+    }
+    .tx-card__content {
+        width: 70%;
+        flex-grow: 1;
+    }
+    .tx-card__subtitle {
+        font-size: 12px;
+    }
+    .tx-card__right {
+        flex-grow: 1;
+        text-align: right;
+    }
+    .tx-card__right__title {
+        font-weight: bold;
+        text-wrap: nowrap;
+    }
 `;
 
 export default ({
@@ -102,6 +130,7 @@ export default ({
     availableBalance,
     fromLabelId,
     privateShardInfo,
+    transactions,
 }) => {
     const isTransferTransaction = new BN(transferAmount).gt(new BN(0));
     return (
@@ -122,7 +151,12 @@ export default ({
                     showBalanceInUSD={!privateShardInfo}
                 />
             )}
-            <div className={`account from ${!isTransferTransaction ? 'no-border' : ''}`}>
+            {transactions.map((transaction, i) => {
+                return (
+                    <TransactionInterpretationItem key={i} transaction={transaction} />
+                );
+            })}
+            <div className={'account'}>
                 <Translate id={fromLabelId || 'transfer.from'} />
                 <div className='right'>
                     <div className='account-id'>{sender}</div>

--- a/packages/frontend/src/components/sign/v2/SignTransactionSummary.js
+++ b/packages/frontend/src/components/sign/v2/SignTransactionSummary.js
@@ -10,6 +10,8 @@ import FormButtonGroup from '../../common/FormButtonGroup';
 import Container from '../../common/styled/Container.css';
 import ConnectWithApplication from '../../login/v2/ConnectWithApplication';
 import ConnectWithPrivateShard from '../../login/v2/ConnectWithPrivateShard';
+import { useSelector } from 'react-redux';
+import { selectSignTransactions } from '../../../redux/slices/sign';
 
 const StyledContainer = styled(Container)`
     &&& {
@@ -63,6 +65,7 @@ export default ({
         availableBalance &&
         transferAmount &&
         new BN(availableBalance).lt(new BN(transferAmount));
+    const transactions = useSelector(selectSignTransactions);
     return (
         <StyledContainer className='small-centered border'>
             <h3>
@@ -77,11 +80,11 @@ export default ({
                 <AlertBanner title='sign.insufficientFundsDesc' theme='warning' />
             )}
             <SignTransaction
-                transferAmount={transferAmount}
                 sender={accountLocalStorageAccountId}
                 estimatedFees={estimatedFees}
                 availableBalance={availableBalance}
                 privateShardInfo={privateShardInfo}
+                transactions={transactions}
             />
             <FormButton className='link' onClick={onClickMoreInformation}>
                 <Translate id='button.moreInformation' />

--- a/packages/frontend/src/components/sign/v2/TransactionInterpretationItem.tsx
+++ b/packages/frontend/src/components/sign/v2/TransactionInterpretationItem.tsx
@@ -74,10 +74,12 @@ const TransactionInterpretationItem = ({ transaction }: Props) => {
         CONFIG.CURRENT_NEAR_NETWORK
     );
 
+    const hasImage = data?.[txUIRaw.args?.nft_contract_id]?.icon || !!txUI.image;
+
     return (
         <div className='account tx-card from no-border'>
             <div className='tx-card__icon'>
-                {!!txUI.image && (
+                {hasImage && (
                     <ImageWithLoading
                         src={data?.[txUIRaw.args?.nft_contract_id]?.icon || txUI.image}
                         alt='transaction-icon'
@@ -91,17 +93,19 @@ const TransactionInterpretationItem = ({ transaction }: Props) => {
                 <div className='tx-card__subtitle'>{txUI.subtitle}</div>
             </div>
             <div className='tx-card__right'>
-                <div
-                    className={classNames([
-                        'tx-card__right__title',
-                        {
-                            'text-green': txUI.dir !== ETxDirection.send,
-                        },
-                    ])}
-                >
-                    {getPrefixByDir(txUI.dir)}
-                    {txUI.assetChangeText}
-                </div>
+                {!!txUI.assetChangeText && (
+                    <div
+                        className={classNames([
+                            'tx-card__right__title',
+                            {
+                                'text-green': txUI.dir !== ETxDirection.send,
+                            },
+                        ])}
+                    >
+                        {getPrefixByDir(txUI.dir)}
+                        {txUI.assetChangeText}
+                    </div>
+                )}
                 {!!txUI.assetChangeText2 && (
                     <div className='asset-change2'>-{txUI.assetChangeText2}</div>
                 )}

--- a/packages/frontend/src/components/sign/v2/TransactionInterpretationItem.tsx
+++ b/packages/frontend/src/components/sign/v2/TransactionInterpretationItem.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import ImageWithLoading from '../../common/image/ImageWithLoading';
+import classNames from '../../../utils/classNames';
+import { ETxDirection } from '../../transactions/TransactionItem';
+import {
+    getPrefixByDir,
+    transactionToHistoryUIData,
+} from '../../../redux/slices/transactionHistory/utils';
+import { useSelector } from 'react-redux';
+import { selectAccountId } from '../../../redux/slices/account';
+import { useQuery } from 'react-query';
+import { keysToSnakeCase } from '../../../utils/object';
+import CONFIG from '../../../config';
+import { fetchAllMetaData } from '../../../redux/slices/transactionHistory';
+
+type Props = {
+    transaction: any;
+};
+
+const TransactionInterpretationItem = ({ transaction }: Props) => {
+    const accountId = useSelector(selectAccountId);
+    const txData = {
+        transaction: {
+            ...keysToSnakeCase(transaction),
+            actions: transaction.actions.map((action) => {
+                return Object.entries(action).reduce((acc, [key, value]) => {
+                    return {
+                        ...acc,
+                        [key.charAt(0).toUpperCase() + key.slice(1)]:
+                            keysToSnakeCase(value),
+                    };
+                }, {});
+            }),
+        },
+        transaction_outcome: {
+            outcome: {
+                status: {},
+            },
+        },
+        receipts: [],
+        metaData: {},
+        status: {},
+        isPreTransaction: true,
+    };
+
+    const txUIRaw = transactionToHistoryUIData(
+        txData,
+        accountId,
+        CONFIG.CURRENT_NEAR_NETWORK
+    );
+
+    const { data } = useQuery({
+        queryKey: ['signTxMetadata', transaction, txUIRaw.args?.nft_contract_id],
+        queryFn: async () => {
+            const allReceiver =
+                txUIRaw.isNft && txUIRaw.args?.nft_contract_id
+                    ? [transaction.receiverId, txUIRaw.args.nft_contract_id]
+                    : [transaction.receiverId];
+            const metaDatas = await fetchAllMetaData({}, allReceiver);
+            return metaDatas;
+        },
+        enabled: !!transaction,
+    });
+
+    const txUI = transactionToHistoryUIData(
+        {
+            ...txData,
+            metaData:
+                data?.[transaction?.receiverId] ||
+                data?.[txUIRaw.args?.nft_contract_id] ||
+                {},
+        },
+        accountId,
+        CONFIG.CURRENT_NEAR_NETWORK
+    );
+
+    return (
+        <div className='account tx-card from no-border'>
+            <div className='tx-card__icon'>
+                {!!txUI.image && (
+                    <ImageWithLoading
+                        src={data?.[txUIRaw.args?.nft_contract_id]?.icon || txUI.image}
+                        alt='transaction-icon'
+                        loadImageTimeout={60_000}
+                        style={{ objectFit: 'contain' }}
+                    />
+                )}
+            </div>
+            <div className='tx-card__content'>
+                <div className='tx-card__title'>{txUI.title}</div>
+                <div className='tx-card__subtitle'>{txUI.subtitle}</div>
+            </div>
+            <div className='tx-card__right'>
+                <div
+                    className={classNames([
+                        'tx-card__right__title',
+                        {
+                            'text-green': txUI.dir !== ETxDirection.send,
+                        },
+                    ])}
+                >
+                    {getPrefixByDir(txUI.dir)}
+                    {txUI.assetChangeText}
+                </div>
+                {!!txUI.assetChangeText2 && (
+                    <div className='asset-change2'>-{txUI.assetChangeText2}</div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default TransactionInterpretationItem;

--- a/packages/frontend/src/redux/slices/transactionHistory/index.ts
+++ b/packages/frontend/src/redux/slices/transactionHistory/index.ts
@@ -73,7 +73,7 @@ const transactionHistorySlice = createSlice({
     },
 });
 
-async function fetchAllMetaData(state, allReceiver: string[]) {
+export async function fetchAllMetaData(state, allReceiver: string[]) {
     const res: any = await Promise.allSettled([
         ...allReceiver.map((contractName) => {
             return getCachedContractMetadataOrFetch(contractName, state);

--- a/packages/frontend/src/redux/slices/transactionHistory/transactionPattern.tsx
+++ b/packages/frontend/src/redux/slices/transactionHistory/transactionPattern.tsx
@@ -8,6 +8,7 @@ import {
     TxMethodName,
     methodNameShowlist,
     nearMetadata,
+    wNearMetadata,
 } from './constant';
 import {
     ETransactionStatus,
@@ -176,7 +177,10 @@ class TransferFtPattern implements TxPattern {
         const dir = txUtils.getTxDirection(data, accountId);
         const isReceived = dir === ETxDirection.receive;
         return {
-            image: data.metaData.icon || '',
+            image:
+                data.metaData.symbol === wNearMetadata.symbol
+                    ? wNearMetadata.icon
+                    : data.metaData.icon,
             title: isReceived ? 'Received' : 'Sent',
             subtitle: isReceived
                 ? `from ${data.transaction.signer_id}`

--- a/packages/frontend/src/redux/slices/transactionHistory/type.ts
+++ b/packages/frontend/src/redux/slices/transactionHistory/type.ts
@@ -30,6 +30,7 @@ export interface TransactionItemComponent {
     transactionHash?: string;
     hasError?: boolean;
     isNft?: boolean;
+    args?: { [key: string]: string };
 }
 
 interface ITxAction {

--- a/packages/frontend/src/redux/slices/transactionHistory/type.ts
+++ b/packages/frontend/src/redux/slices/transactionHistory/type.ts
@@ -46,6 +46,7 @@ interface ITxAction {
 }
 
 export type IMetaData = {
+    id: string;
     icon: string | null;
     decimals: number;
     symbol: string;


### PR DESCRIPTION
## Changes description
When signing from dapps, should show transaction interpretation. Users should understand what they signing, for example, sending fund before they approve the transaction

## Preview
- Ref finance swap
<img width="537" alt="Screenshot 2024-08-07 at 15 45 00" src="https://github.com/user-attachments/assets/bc1279d9-b8b6-4b85-8fa0-4227e6b5dc82">


- Ref finance add liquidity
<img width="537" alt="Screenshot 2024-08-06 at 18 23 40" src="https://github.com/user-attachments/assets/15a78f25-14a9-4276-9970-8e4994af3531">


- Ref finance stake liquidity pool
<img width="537" alt="Screenshot 2024-08-06 at 16 23 24" src="https://github.com/user-attachments/assets/dcc96e90-1b3f-493e-a2b2-58abf48315f6">


- Burrow supply
<img width="647" alt="Screenshot 2024-08-02 at 16 33 41" src="https://github.com/user-attachments/assets/c643cb28-ee23-41bc-b6b7-8e4c6d3281c9">

- Burrow staking
<img width="546" alt="Screenshot 2024-08-08 at 12 13 40" src="https://github.com/user-attachments/assets/26277d25-6617-4119-81a9-d6c1297af38c">

- Burrow withdraw
<img width="546" alt="Screenshot 2024-08-08 at 12 13 40" src="https://github.com/user-attachments/assets/afbc1ca9-72e9-4343-b821-217321b02599">

- Paras buy nft
<img width="647" alt="Screenshot 2024-08-02 at 18 34 00" src="https://github.com/user-attachments/assets/2c087c97-3421-402e-abc1-7bc203166d0d">

- Linear staking
<img width="537" alt="Screenshot 2024-08-07 at 14 10 18" src="https://github.com/user-attachments/assets/df3cdc91-92c2-485e-947c-146181a22d6a">


- Linear liquid unstake
<img width="537" alt="Screenshot 2024-08-07 at 14 08 05" src="https://github.com/user-attachments/assets/fcb9bfae-052b-4385-b912-263426e7181f">
