### PR TITLE
fix(stake): ux, liquid unstake interpret

### DIFF
--- a/packages/frontend/src/components/staking/components/ValidatorBoxItem.tsx
+++ b/packages/frontend/src/components/staking/components/ValidatorBoxItem.tsx
@@ -45,7 +45,7 @@ const ValidatorBoxItem = ({
 }: Props) => {
     const history = useHistory();
     return (
-        <Container>
+        <Container className='validator-box-container'>
             <div
                 onClick={onClick}
                 className='validator-box'

--- a/packages/frontend/src/components/staking/liquid-staking/StakingForm.tsx
+++ b/packages/frontend/src/components/staking/liquid-staking/StakingForm.tsx
@@ -6,6 +6,7 @@ import { formatNearAmount, parseNearAmount } from 'near-api-js/lib/utils/format'
 import { useMutation } from 'react-query';
 import { FinalExecutionStatus } from 'near-api-js/lib/providers';
 import { useParams } from 'react-router';
+import styled from 'styled-components';
 
 import FormButton from '../../common/FormButton';
 import ArrowCircleIcon from '../../svg/ArrowCircleIcon';
@@ -87,7 +88,7 @@ const StakingForm = () => {
     }
 
     return (
-        <Container className='small-centered'>
+        <StyledContainer className='small-centered'>
             <div className='send-theme'>
                 <h1>
                     <Translate id={'staking.stake.title'} />
@@ -96,13 +97,16 @@ const StakingForm = () => {
                     <Translate id={'staking.stake.desc'} />
                 </h2>
                 <div className='amount-header-wrapper'>
+                    <h4>
+                        <Translate id='staking.stake.amount' />
+                    </h4>
                     <FormButton
-                        className='small'
-                        color='light-blue'
                         onClick={handleSetMax}
-                        data-test-id='stakingPageUseMaxButton'
+                        type='button'
+                        color='light-blue'
+                        className='max-button small'
                     >
-                        <Translate id='staking.stake.useMax' />
+                        <Translate id='button.useMax' />
                     </FormButton>
                 </div>
                 <AmountInput
@@ -155,8 +159,24 @@ const StakingForm = () => {
                     <Translate id={'staking.stake.button'} />
                 </FormButton>
             </div>
-        </Container>
+        </StyledContainer>
     );
 };
 
 export default StakingForm;
+
+const StyledContainer = styled(Container)`
+    &&& {
+        .max-button {
+            margin: 0;
+        }
+    }
+    .amount-header-wrapper {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+    .validator-box-container {
+        border-top: 2px solid #f2f2f2;
+    }
+`;

--- a/packages/frontend/src/components/staking/liquid-staking/UnstakeForm.tsx
+++ b/packages/frontend/src/components/staking/liquid-staking/UnstakeForm.tsx
@@ -38,7 +38,6 @@ const UnstakeForm = () => {
     const [unstakeType, setUnstakeType] = useState(UnstakeType.instant);
     const accountId = useSelector(selectAccountId);
     const { validatorId }: { validatorId: string } = useParams();
-    console.log({ unstakeAmount });
 
     const liquidUnstakeMutation = useMutation({
         mutationFn: async (amount: string) => {

--- a/packages/frontend/src/components/staking/liquid-staking/UnstakeForm.tsx
+++ b/packages/frontend/src/components/staking/liquid-staking/UnstakeForm.tsx
@@ -144,14 +144,19 @@ const UnstakeForm = () => {
                 <h2>
                     <Translate id={'staking.unstake.desc'} />
                 </h2>
-                <FormButton
-                    onClick={handleClickMax}
-                    type='button'
-                    color='light-blue'
-                    className='max-button small'
-                >
-                    <Translate id='button.useMax' />
-                </FormButton>
+                <div className='amount-header-wrapper'>
+                    <h4>
+                        <Translate id='staking.stake.amount' />
+                    </h4>
+                    <FormButton
+                        onClick={handleClickMax}
+                        type='button'
+                        color='light-blue'
+                        className='max-button small'
+                    >
+                        <Translate id='button.useMax' />
+                    </FormButton>
+                </div>
                 <AmountInput
                     action={'unstake'}
                     value={unstakeAmount}
@@ -287,6 +292,14 @@ const StyledContainer = styled(Container)`
     .unstake-tab__item.active {
         border: 1px solid #148402;
         color: #148402;
+    }
+    .amount-header-wrapper {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+    .validator-box-container {
+        border-top: 2px solid #f2f2f2;
     }
     &&& {
         .max-button {

--- a/packages/frontend/src/components/transactions/ExecutorModal/TransactionExecutorModal.tsx
+++ b/packages/frontend/src/components/transactions/ExecutorModal/TransactionExecutorModal.tsx
@@ -68,6 +68,7 @@ const TransactionExecutorModal = () => {
                                 receipts: [],
                                 metaData: {},
                                 status: {},
+                                isPreTransaction: true,
                             },
                             accountId,
                             CONFIG.CURRENT_NEAR_NETWORK

--- a/packages/frontend/src/redux/slices/transactionHistory/transactionPattern.tsx
+++ b/packages/frontend/src/redux/slices/transactionHistory/transactionPattern.tsx
@@ -734,11 +734,12 @@ class ClaimUnStakePattern implements TxPattern {
         let amount = '0';
         let metaData = {};
 
+        const isMetapool = data.transaction.receiver_id === METAPOOL_CONTRACT_ID;
         for (const r of data.receipts) {
             const transfer = r.receipt.Action?.actions?.[0]?.Transfer;
             if (transfer?.deposit) {
                 amount = transfer.deposit;
-                if (r.metaData) {
+                if (r.metaData && !isMetapool) {
                     metaData = r.metaData;
                 }
                 break;
@@ -749,7 +750,11 @@ class ClaimUnStakePattern implements TxPattern {
             image: imgClaim,
             title: 'Claim Unstaked Near',
             subtitle: `from ${data.transaction.receiver_id}`,
-            assetChangeText: txUtils.getAmount(data, amount, metaData),
+            assetChangeText: txUtils.getAmount(
+                isMetapool ? { ...data, metaData: null } : data,
+                amount,
+                isMetapool ? nearMetadata : metaData
+            ),
             status: txUtils.getTxStatus(data),
             dir: ETxDirection.receive,
             ...txUtils.defaultDisplay(data),

--- a/packages/frontend/src/redux/slices/transactionHistory/transactionPattern.tsx
+++ b/packages/frontend/src/redux/slices/transactionHistory/transactionPattern.tsx
@@ -750,13 +750,15 @@ class ClaimUnStakePattern implements TxPattern {
             image: imgClaim,
             title: 'Claim Unstaked Near',
             subtitle: `from ${data.transaction.receiver_id}`,
-            assetChangeText: txUtils.getAmount(
-                isMetapool ? { ...data, metaData: null } : data,
-                amount,
-                isMetapool ? nearMetadata : metaData
-            ),
+            assetChangeText: data.isPreTransaction
+                ? ''
+                : txUtils.getAmount(
+                      isMetapool ? { ...data, metaData: null } : data,
+                      amount,
+                      isMetapool ? nearMetadata : metaData
+                  ),
             status: txUtils.getTxStatus(data),
-            dir: ETxDirection.receive,
+            ...(!data.isPreTransaction && { dir: ETxDirection.receive }),
             ...txUtils.defaultDisplay(data),
         };
     }

--- a/packages/frontend/src/redux/slices/transactionHistory/transactionPattern.tsx
+++ b/packages/frontend/src/redux/slices/transactionHistory/transactionPattern.tsx
@@ -551,16 +551,26 @@ class DelayedLiquidUnStakePattern implements TxPattern {
     }
 
     display(data: TxData): TransactionItemComponent {
-        const args = txUtils.getFcArgs(data);
+        let amount = '0';
+        try {
+            for (const r of data.receipts_outcome) {
+                for (const l of r.outcome?.logs || []) {
+                    if (l.includes('EVENT_JSON')) {
+                        const log = JSON.parse(l.replace('EVENT_JSON:', '') || '{}');
+                        if (log.standard === 'nep141') {
+                            amount = log.data[0].amount;
+                        }
+                    }
+                }
+            }
+        } catch (err) {
+            console.error('parse nft mint log error');
+        }
         return {
             image: imgUnStaked,
             title: 'Delayed Unstake',
             subtitle: `with ${data.transaction.receiver_id}`,
-            assetChangeText: txUtils.getAmount(
-                { ...data, metaData: null },
-                args.amount,
-                nearMetadata
-            ),
+            assetChangeText: txUtils.getAmount(data, amount, nearMetadata),
             status: txUtils.getTxStatus(data),
             dir: ETxDirection.send,
             ...txUtils.defaultDisplay(data),


### PR DESCRIPTION
## Changes description
- Liquid stake, unstake form button usemax
- Transaction history liquid unstake

## Preview
<img width="813" alt="Screenshot 2024-08-19 at 10 22 49" src="https://github.com/user-attachments/assets/fb452906-ad21-43df-a397-44c6fb26ea15">

<img width="813" alt="Screenshot 2024-08-19 at 10 24 44" src="https://github.com/user-attachments/assets/272aa073-7a0e-4ea4-b722-e747321acc64">

