### PR TITLE
fix(staking): fix apy when validator not have farm data

### DIFF
--- a/packages/frontend/src/components/staking/components/FarmingAPY.js
+++ b/packages/frontend/src/components/staking/components/FarmingAPY.js
@@ -40,7 +40,7 @@ const Container = styled.div`
 export function FarmingAPY({ apy, hideTooltip }) {
     return (
         <Container className='farming-apy'>
-            <Translate id='staking.validator.apy' />
+            <Translate id='staking.validator.farmApy' />
             {!hideTooltip && <Tooltip translate='staking.balanceBox.farm.info' />}
             <span className='fee'>{apy}%</span>
         </Container>

--- a/packages/frontend/src/components/staking/components/ValidatorBox.js
+++ b/packages/frontend/src/components/staking/components/ValidatorBox.js
@@ -201,19 +201,19 @@ export default function ValidatorBox({
                     <div className='text-left'>
                         {isFarmingValidator && (
                             <>
-                                <span>
-                                    <Translate id='staking.validator.apy' />
-                                    &nbsp;
-                                </span>
                                 {farmAPY === null && validator.active ? (
                                     <span
                                         className='animated-dots'
                                         style={{ width: 16 }}
                                     />
                                 ) : (
-                                    <span>{farmAPY || 0}</span>
+                                    <span>{farmAPY || 0}%&nbsp;</span>
                                 )}
-                                <span>%&nbsp;-&nbsp;</span>
+                                <span>
+                                    <Translate id='staking.validator.farmApy' />
+                                    &nbsp;
+                                </span>
+                                <span>-&nbsp;</span>
                             </>
                         )}
                         <span>

--- a/packages/frontend/src/translations/locales/en/translation.json
+++ b/packages/frontend/src/translations/locales/en/translation.json
@@ -1739,6 +1739,7 @@
         "validator": {
             "activeStake": "Active Stake",
             "apy": "APY",
+            "farmApy": "Farm APY",
             "button": "Stake With Validator",
             "claimFarmRewards": "You are claiming",
             "claiming": "Claiming",


### PR DESCRIPTION
## Changes
Validator that have no farm was show as 0 APY, should show as Farm APY

## Preview
<img width="674" alt="Screenshot 2024-08-26 at 15 52 52" src="https://github.com/user-attachments/assets/dcd13e48-42f2-4430-8623-f32c3ae34588">

@race-of-sloths