### PR TITLE
fix: update account helper url

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/development.ts
+++ b/packages/frontend/src/config/environmentDefaults/development.ts
@@ -3,7 +3,7 @@ import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
     ACCOUNT_HELPER_URL: 'https://api-testnet.nearblocks.io/v1/kitwallet',
-    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.testnet.near.org/',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.testnet.near.org',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     DISABLE_CREATE_ACCOUNT: false,

--- a/packages/frontend/src/config/environmentDefaults/development.ts
+++ b/packages/frontend/src/config/environmentDefaults/development.ts
@@ -3,7 +3,7 @@ import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
     ACCOUNT_HELPER_URL: 'https://api-testnet.nearblocks.io/v1/kitwallet',
-    ACCOUNT_KITWALLET_HELPER_URL: 'https://testnet-api.kitwallet.app',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.testnet.near.org/',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     DISABLE_CREATE_ACCOUNT: false,

--- a/packages/frontend/src/config/environmentDefaults/mainnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.ts
@@ -3,7 +3,7 @@ import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
     ACCOUNT_HELPER_URL: 'https://api3.nearblocks.io/v1/kitwallet',
-    ACCOUNT_KITWALLET_HELPER_URL: 'https://api.kitwallet.app',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.mainnet.near.org/',
     ACCOUNT_ID_SUFFIX: 'near',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     BROWSER_MIXPANEL_TOKEN: '7c5730e5b3556a06b73829b3c3b40a86',

--- a/packages/frontend/src/config/environmentDefaults/mainnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.ts
@@ -3,7 +3,7 @@ import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
     ACCOUNT_HELPER_URL: 'https://api3.nearblocks.io/v1/kitwallet',
-    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.mainnet.near.org/',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.mainnet.near.org',
     ACCOUNT_ID_SUFFIX: 'near',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     BROWSER_MIXPANEL_TOKEN: '7c5730e5b3556a06b73829b3c3b40a86',

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
@@ -3,7 +3,7 @@ import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
     ACCOUNT_HELPER_URL: 'https://api3.nearblocks.io/v1/kitwallet',
-    ACCOUNT_KITWALLET_HELPER_URL: 'https://api.kitwallet.app',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.mainnet.near.org/',
     ACCOUNT_ID_SUFFIX: 'near',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     BROWSER_MIXPANEL_TOKEN: '7c5730e5b3556a06b73829b3c3b40a86',

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
@@ -3,7 +3,7 @@ import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
     ACCOUNT_HELPER_URL: 'https://api3.nearblocks.io/v1/kitwallet',
-    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.mainnet.near.org/',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.mainnet.near.org',
     ACCOUNT_ID_SUFFIX: 'near',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     BROWSER_MIXPANEL_TOKEN: '7c5730e5b3556a06b73829b3c3b40a86',

--- a/packages/frontend/src/config/environmentDefaults/testnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet.ts
@@ -3,7 +3,7 @@ import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
     ACCOUNT_HELPER_URL: 'https://api-testnet.nearblocks.io/v1/kitwallet',
-    ACCOUNT_KITWALLET_HELPER_URL: 'https://testnet-api.kitwallet.app',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.testnet.near.org',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     BROWSER_MIXPANEL_TOKEN: '778bd24eec7329cf885f0cecfc3d4f5d',

--- a/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
@@ -3,7 +3,7 @@ import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
     ACCOUNT_HELPER_URL: 'https://api-testnet.nearblocks.io/v1/kitwallet',
-    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.testnet.near.org/',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.testnet.near.org',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     BROWSER_MIXPANEL_TOKEN: '778bd24eec7329cf885f0cecfc3d4f5d',

--- a/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/testnet_STAGING.ts
@@ -3,7 +3,7 @@ import { parseNearAmount } from 'near-api-js/lib/utils/format';
 
 export default {
     ACCOUNT_HELPER_URL: 'https://api-testnet.nearblocks.io/v1/kitwallet',
-    ACCOUNT_KITWALLET_HELPER_URL: 'https://testnet-api.kitwallet.app',
+    ACCOUNT_KITWALLET_HELPER_URL: 'https://helper.testnet.near.org/',
     ACCOUNT_ID_SUFFIX: 'testnet',
     ACCESS_KEY_FUNDING_AMOUNT: nearApiJs.utils.format.parseNearAmount('0.25'),
     BROWSER_MIXPANEL_TOKEN: '778bd24eec7329cf885f0cecfc3d4f5d',


### PR DESCRIPTION
Account helper URLs have moved to

- https://helper.mainnet.near.org/
- https://helper.testnet.near.org/