### PR TITLE
perf(rpc): reduce rpc spam swap data, nfts

### DIFF
--- a/packages/frontend/src/components/common/Updater.js
+++ b/packages/frontend/src/components/common/Updater.js
@@ -3,16 +3,13 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import useInterval from '../../hooks/useInterval';
 import { selectAccountId } from '../../redux/slices/account';
-import { actions as swapActions } from '../../redux/slices/swap';
 import { actions as tokenFiatValuesActions } from '../../redux/slices/tokenFiatValues';
 import { actions as tokensActions } from '../../redux/slices/tokens';
 
 const { fetchTokenFiatValues } = tokenFiatValuesActions;
 const { fetchTokens } = tokensActions;
-const { fetchSwapData } = swapActions;
 
 const THIRTY_SECONDS = 30_000;
-const ONE_MINUTE = THIRTY_SECONDS * 2;
 
 export default function Updater() {
     const dispatch = useDispatch();
@@ -27,16 +24,6 @@ export default function Updater() {
     useInterval(() => {
         dispatch(fetchTokenFiatValues());
     }, THIRTY_SECONDS);
-
-    useInterval(
-        () => {
-            if (accountId) {
-                dispatch(fetchSwapData({ accountId }));
-            }
-        },
-        ONE_MINUTE,
-        [accountId]
-    );
 
     return null;
 }

--- a/packages/frontend/src/components/wallet/NFTs.js
+++ b/packages/frontend/src/components/wallet/NFTs.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Translate } from 'react-localize-redux';
 import styled from 'styled-components';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import NFTBox from './NFTBox';
 import FormButton from '../common/FormButton';
@@ -9,6 +9,7 @@ import NearCircleIcon from '../svg/NearCircleIcon.js';
 import {
     selectLoadingOwnedToken,
     selectTokensWithMetadataForAccountId,
+    actions as nftActions,
 } from '../../redux/slices/nft';
 import LoadingDots from '../common/loader/LoadingDots';
 
@@ -71,12 +72,19 @@ const StyledLoadingContainer = styled.div`
 `;
 
 const NFTs = ({ accountId }) => {
+    const dispatch = useDispatch();
     const tokens = useSelector((state) =>
         selectTokensWithMetadataForAccountId(state, { accountId })
     );
     const isLoadingTokens = useSelector((state) =>
         selectLoadingOwnedToken(state, { accountId })
     );
+
+    useEffect(() => {
+        if (accountId) {
+            dispatch(nftActions.fetchNFTs({ accountId }));
+        }
+    }, [accountId]);
 
     const ownedTokens = tokens.filter(
         (tokenDetails) =>

--- a/packages/frontend/src/pages/TokenSwap/TokenSwap.js
+++ b/packages/frontend/src/pages/TokenSwap/TokenSwap.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { SwapProvider } from './model/Swap';
 import SwapWrapper from './ui/SwapWrapper';
@@ -7,17 +7,20 @@ import useTokens from './utils/hooks/useTokens';
 import Container from '../../components/common/styled/Container.css';
 import { selectAccountId } from '../../redux/slices/account';
 import { wallet } from '../../utils/wallet';
+import { actions as swapActions } from '../../redux/slices/swap';
 
 const TokenSwap = ({ history }) => {
     const accountId = useSelector(selectAccountId);
     const [account, setAccount] = useState(null);
     const tokensConfig = useTokens();
+    const dispatch = useDispatch();
 
     useEffect(() => {
         let mounted = true;
 
         if (accountId) {
             const updateAccount = async () => {
+                dispatch(swapActions.fetchSwapData({ accountId }));
                 const instance = await wallet.getAccount(accountId, true);
 
                 if (mounted) {

--- a/packages/frontend/src/pages/TokenSwap/ui/SwapForm.js
+++ b/packages/frontend/src/pages/TokenSwap/ui/SwapForm.js
@@ -23,6 +23,7 @@ import {
     NOTIFICATION_TYPE,
 } from '../utils/constants';
 import useSwapInfo from '../utils/hooks/useSwapInfo';
+import LoadingDots from '../../../components/common/loader/LoadingDots';
 
 const mobile = isMobile();
 
@@ -303,19 +304,23 @@ const SwapForm = memo(({ onGoBack, account, tokensConfig }) => {
                     <SwapButtonWrapper>
                         <FlipButton onClick={flipInputsData} />
                     </SwapButtonWrapper>
-                    <Input
-                        value={amountOut}
-                        onSelectToken={selectTokenOut}
-                        labelId='swap.to'
-                        tokenSymbol={tokenOut?.onChainFTMetadata?.symbol}
-                        tokenIcon={tokenOut?.onChainFTMetadata?.icon}
-                        tokenDecimals={tokenOut?.onChainFTMetadata?.decimals}
-                        maxBalance={tokenOut?.balance}
-                        loading={loading}
-                        inputTestId='swapPageOutputAmountField'
-                        tokenSelectTestId='swapPageOutputTokenSelector'
-                        disabled
-                    />
+                    {tokensConfig.isLoadingAllTokens ? (
+                        <LoadingDots />
+                    ) : (
+                        <Input
+                            value={amountOut}
+                            onSelectToken={selectTokenOut}
+                            labelId='swap.to'
+                            tokenSymbol={tokenOut?.onChainFTMetadata?.symbol}
+                            tokenIcon={tokenOut?.onChainFTMetadata?.icon}
+                            tokenDecimals={tokenOut?.onChainFTMetadata?.decimals}
+                            maxBalance={tokenOut?.balance}
+                            loading={loading}
+                            inputTestId='swapPageOutputAmountField'
+                            tokenSelectTestId='swapPageOutputTokenSelector'
+                            disabled
+                        />
+                    )}
                     <Footer>
                         <SwapDetails />
 

--- a/packages/frontend/src/pages/TokenSwap/utils/hooks/useTokens.js
+++ b/packages/frontend/src/pages/TokenSwap/utils/hooks/useTokens.js
@@ -34,5 +34,6 @@ export default function useTokens() {
         listOfTokensIn: Object.values(tokensIn),
         tokensOut,
         listOfTokensOut: Object.values(tokensOut),
+        isLoadingAllTokens: !Object.values(allTokens).length,
     };
 }

--- a/packages/frontend/src/routes/WalletWrapper.js
+++ b/packages/frontend/src/routes/WalletWrapper.js
@@ -22,13 +22,11 @@ import {
     selectLinkdropAmount,
     actions as linkdropActions,
 } from '../redux/slices/linkdrop';
-import { actions as nftActions } from '../redux/slices/nft';
 import {
     actions as recoveryMethodsActions,
     selectRecoveryMethodsByAccountId,
 } from '../redux/slices/recoveryMethods';
 
-const { fetchNFTs } = nftActions;
 const { setLinkdropAmount } = linkdropActions;
 const { setCreateFromImplicitSuccess, setCreateCustomName } = createFromImplicitActions;
 const { setZeroBalanceAccountImportMethod } = importZeroBalanceAccountActions;
@@ -54,8 +52,6 @@ const WalletWrapper = ({ tab, setTab }) => {
         if (accountId) {
             Mixpanel.identify(Mixpanel.get_distinct_id());
             Mixpanel.people.set({ relogin_date: new Date().toString() });
-
-            dispatch(fetchNFTs({ accountId }));
 
             if (userRecoveryMethods.length === 0) {
                 dispatch(fetchRecoveryMethods({ accountId }));


### PR DESCRIPTION
## Changes description
Reduce initial page load rpc spam call

## Preview
Before: 700x api call
<img width="1440" alt="Screenshot 2024-11-25 at 15 20 35" src="https://github.com/user-attachments/assets/3ea06a7b-4398-4997-9c3a-556cc4f3382a">

After: 300x api call
<img width="1440" alt="Screenshot 2024-11-25 at 15 20 50" src="https://github.com/user-attachments/assets/5e74cfc9-e9fd-4afb-9226-b2ff45e3a53a">

@race-of-sloths