### PR TITLE
feat: wallet-selector no longer include callback to sign

### DIFF
--- a/packages/frontend/src/routes/SignMessageWrapper.js
+++ b/packages/frontend/src/routes/SignMessageWrapper.js
@@ -83,7 +83,7 @@ const SignMessageWrapper = () => {
                 message: accountUrlMessage,
                 nonce: accountUrlNonce,
                 recipient: accountUrlRecipient,
-                callbackUrl: accountUrlCallbackUrl,
+                callbackUrl: window.opener ? undefined : accountUrlCallbackUrl,
             })
         );
 

--- a/packages/guestbook/src/components/Content.tsx
+++ b/packages/guestbook/src/components/Content.tsx
@@ -222,7 +222,7 @@ const Content: React.FC = () => {
                 message: 'test message for verification',
                 nonce: Buffer.from('30990309-30990309-390A303-292090'),
                 recipient: 'test.app',
-                callbackUrl: 'http://localhost:4200',
+                callbackUrl: window.opener ? undefined : 'http://localhost:4200',
             });
 
             if (signature) {


### PR DESCRIPTION
MyNearWallet currently always includes the callbackUrl in signMessage, this makes MNW behave different than other wallets.

With the new release of wallet-selector, MNW will now open in a pop-up window, for which users will also expect it to work in the same way as other wallets, i.e. to not include the callbackUrl in the signMessage

This PR changes MNW, so it includes the callbackURL when called as a BrowserWallet (i.e. it redirects the user), and excludes it when using MNW as a Injected Wallet (i.e. in a pop-up)
