### PR TITLE
Fix: Update discord link

### DIFF
--- a/packages/frontend/src/components/common/Footer.js
+++ b/packages/frontend/src/components/common/Footer.js
@@ -132,7 +132,7 @@ const Footer = () => {
                 <Translate id='footer.needHelp' />
                 <br />
                 <a
-                    href='https://discord.com/invite/Vj74PpQYsh'
+                    href='https://discord.gg/XUPPddjVcr'
                     rel='noopener noreferrer'
                     target='_blank'
                     onClick={() => Mixpanel.track('Footer Click Join Community')}

--- a/packages/frontend/src/components/common/GlobalAlert.js
+++ b/packages/frontend/src/components/common/GlobalAlert.js
@@ -184,7 +184,7 @@ const GlobalAlertNew = ({
 }) => {
     const [closing, setClosing] = useState(false);
     const [alerts, setAlerts] = useState([]);
-    const zendeskBaseURL = 'https://nearhelp.zendesk.com/hc/';
+    const helpDeskBaseURL = 'https://help.mynearwallet.com/en/';
 
     const handleClose = (type) => {
         setClosing(type);
@@ -278,9 +278,9 @@ const GlobalAlertNew = ({
                                                                     msgCode.includes(
                                                                         'Sorry an error has occurred'
                                                                     )
-                                                                        ? `${zendeskBaseURL}${
+                                                                        ? `${helpDeskBaseURL}${
                                                                               alert.errorMessage
-                                                                                  ? `search?query=${encodeURIComponent(
+                                                                                  ? `search?q=${encodeURIComponent(
                                                                                         alert.errorMessage.substring(
                                                                                             0,
                                                                                             500
@@ -288,7 +288,7 @@ const GlobalAlertNew = ({
                                                                                     )}`
                                                                                   : ''
                                                                           }`
-                                                                        : `${zendeskBaseURL}search?query=${encodeURIComponent(
+                                                                        : `${helpDeskBaseURL}search?q=${encodeURIComponent(
                                                                               msgCode.substring(
                                                                                   0,
                                                                                   500


### PR DESCRIPTION
## Issues

This discord invite is expired [https://discord.com/invite/Vj74PpQYsh](https://discord.com/invite/Vj74PpQYsh)
I found the right link in the [x bio](https://x.com/MyNearWallet) [https://discord.gg/XUPPddjVcr](https://discord.gg/XUPPddjVcr)

1. The discord link in the header and footer of https://www.mynearwallet.com/. 
2. The question? Join community link in the footer of https://app.mynearwallet.com/ 
3. The linktree invite to the discord server is also expired

Also the FAQ popup when a transactions failed still points to zendesk instead of the newer help center supported by gleap: https://help.mynearwallet.com/en 

## Changes description

I replaced the discord link with the version that works

## Preview

The footer:
<img width="1728" alt="Screenshot 2025-03-05 at 17 29 42" src="https://github.com/user-attachments/assets/c285eb6a-2515-4201-9c87-c2e33528dfa2" />

