### PR TITLE
feat: send message when user cancel the login

### DIFF
--- a/packages/frontend/src/components/login/v2/SelectAccountLoginWrapper.js
+++ b/packages/frontend/src/components/login/v2/SelectAccountLoginWrapper.js
@@ -18,6 +18,7 @@ import {
 } from '../../../redux/slices/account';
 import { selectAvailableAccounts } from '../../../redux/slices/availableAccounts';
 import { isUrlNotJavascriptProtocol } from '../../../utils/helper-api';
+import convertUrlToSendMessage from '../../../utils/convertUrlToSendMessage';
 
 export default ({
     loginAccessType,
@@ -56,6 +57,16 @@ export default ({
             onClickCancel={() => {
                 Mixpanel.track('LOGIN Click deny button');
                 if (failureUrl && failureAndSuccessUrlsAreValid) {
+                    if (window.opener) {
+                        return window.opener.postMessage(
+                            {
+                                status: 'failure',
+                                errorCode: 'USER_CANCELLED',
+                                errorMessage: 'User cancelled the Action',
+                            },
+                            convertUrlToSendMessage(failureUrl)
+                        );
+                    }
                     window.location.href = failureUrl;
                 } else {
                     dispatch(redirectToApp());


### PR DESCRIPTION
This update expands on [PR #288](https://github.com/mynearwallet/my-near-wallet/pull/288) with further improvements

Changes Description
- Wallet selector functionality remains unchanged in versions below v9
- Fix the issue when the user clicks "Cancel Login" while using wallet-selector v9, the expected behavior is for the popup to close. However, the current implementation redirects the user instead.


![Captura desde 2025-03-10 21-11-11](https://github.com/user-attachments/assets/b62ecf3e-5d21-4cb1-a084-188cab18e72e)



