### PR TITLE
feat: migrate nearblocks transactions to meteor indexer

### DIFF
--- a/packages/frontend/src/components/transactions/GroupedTransactions.tsx
+++ b/packages/frontend/src/components/transactions/GroupedTransactions.tsx
@@ -14,9 +14,10 @@ import {
 
 type Props = {
     transactions: ITransactionListItem[];
+    isFullpage?: boolean;
 };
 
-const GroupedTransactions = ({ transactions }: Props) => {
+const GroupedTransactions = ({ transactions, isFullpage }: Props) => {
     const accountId = useSelector(selectAccountId);
     const tx = transactions.map((transaction) =>
         transactionToHistoryUIData(transaction, accountId, CONFIG.NETWORK_ID)
@@ -32,6 +33,7 @@ const GroupedTransactions = ({ transactions }: Props) => {
                     return (
                         <TransactionItem
                             key={`${transaction.transactionHash}`}
+                            isFullpage={isFullpage}
                             onClick={() =>
                                 dispatch(
                                     transactionHistoryActions.setSelectedTx(

--- a/packages/frontend/src/components/transactions/TransactionItem.tsx
+++ b/packages/frontend/src/components/transactions/TransactionItem.tsx
@@ -22,6 +22,7 @@ export const TransactionItem = (
     props: TransactionItemComponent & {
         onClick: () => void;
         onClickTransactionHash: () => void;
+        isFullpage?: boolean;
     }
 ) => {
     return (
@@ -48,7 +49,16 @@ export const TransactionItem = (
                         )}
                     </div>
                     <div className='content-subtitle'>
-                        <div className='subtitle'>{props.subtitle}</div>
+                        <div
+                            className={classNames([
+                                'subtitle',
+                                {
+                                    isFullpage: props.isFullpage,
+                                },
+                            ])}
+                        >
+                            {props.subtitle}
+                        </div>
                         {!!props.assetChangeText2 && (
                             <div
                                 className={classNames([
@@ -123,6 +133,9 @@ const StyledContainer = styled(Card)`
             overflow: hidden;
             max-width: 170px;
             text-wrap: nowrap;
+        }
+        .subtitle.isFullpage {
+            max-width: 80%;
         }
         @media (min-width: 992px) {
             .subtitle {

--- a/packages/frontend/src/pages/TransactionHistory/index.tsx
+++ b/packages/frontend/src/pages/TransactionHistory/index.tsx
@@ -17,14 +17,14 @@ const TransactionHistory = () => {
     const dispatch = useDispatch();
     const accountId = useSelector(selectAccountId);
     const { transactions, isLoading, hasMore } = useSelector(transactionHistorySelector);
-    const [page, setPage] = useState(0);
+    const [page, setPage] = useState(1);
 
     if (!transactions) {
         return null;
     }
 
     function loadMore() {
-        if (accountId && !isLoading) {
+        if (accountId && !isLoading && transactions.length > 0) {
             // @ts-ignore:next-line
             dispatch(transactionHistoryActions.fetchTransactions({ accountId, page }));
             setPage((p) => p + 1);
@@ -33,7 +33,7 @@ const TransactionHistory = () => {
 
     // reset on change account
     useEffect(() => {
-        setPage(0);
+        setPage(1);
         dispatch(transactionHistoryActions.setTransactions([]));
         // @ts-ignore:next-line
         dispatch(transactionHistoryActions.fetchTransactions({ accountId, page: 1 }));
@@ -46,7 +46,7 @@ const TransactionHistory = () => {
                     <Translate id='dashboard.activity' />
                 </h2>
                 <InfiniteScroll
-                    pageStart={0}
+                    pageStart={1}
                     loadMore={loadMore}
                     hasMore={hasMore}
                     loader={
@@ -55,7 +55,7 @@ const TransactionHistory = () => {
                         </div>
                     }
                 >
-                    <GroupedTransactions transactions={transactions} />
+                    <GroupedTransactions transactions={transactions} isFullpage />
                 </InfiniteScroll>
                 <TransactionItemModal />
             </StyledContainer>

--- a/packages/frontend/src/redux/slices/transactionHistory/transactionPattern.tsx
+++ b/packages/frontend/src/redux/slices/transactionHistory/transactionPattern.tsx
@@ -870,13 +870,6 @@ class DelegatePattern implements TxPattern {
     }
 }
 
-function TxSubtitle({ texts }) {
-    return `${!!texts[0] && texts[0]}
-            ${texts[1]}
-            ${texts[2]}
-            ${texts[3]}`;
-}
-
 class MultiActionsPattern implements TxPattern {
     match(data: TxData): boolean {
         return data.transaction.actions.length > 1;
@@ -955,9 +948,7 @@ class FunctionCallDefaultPattern implements TxPattern {
         return {
             image: imgAppInteraction,
             title: 'App Interaction',
-            subtitle: TxSubtitle({
-                texts: ['Called', methodName, 'on', data.transaction.receiver_id],
-            }),
+            subtitle: `Called ${methodName} on ${data.transaction.receiver_id}`,
             status: txUtils.getTxStatus(data),
             // assetChangeText:
             //   subCard.length === 1

--- a/packages/frontend/src/redux/slices/transactionHistory/type.ts
+++ b/packages/frontend/src/redux/slices/transactionHistory/type.ts
@@ -1,6 +1,7 @@
 import { FinalExecutionOutcome } from 'near-api-js/lib/providers';
 
 import { TxMethodName } from './constant';
+import { ExecutionOutcomeWithIdView } from 'near-api-js/lib/providers/provider';
 
 export enum ETransactionStatus {
     success = 'success',
@@ -80,9 +81,19 @@ interface WithReceipt {
     receipts: IReceipt[];
 }
 
-export interface ITransactionDetail extends FinalExecutionOutcome, WithReceipt {}
+export interface ITransactionDetail extends FinalExecutionOutcomeView, WithReceipt {}
 
-export interface ITransactionListItem extends FinalExecutionOutcome, WithReceipt {
+export interface ITransactionListItem extends FinalExecutionOutcomeView, WithReceipt {
     metaData: IMetaData;
     receipts: IReceipt[];
+    block_timestamp: string;
+    transaction_hash: string;
+    gas_price: string;
+}
+
+export interface FinalExecutionOutcomeView extends FinalExecutionOutcome {
+    status: FinalExecutionOutcome['status'];
+    transaction: any;
+    transaction_outcome: ExecutionOutcomeWithIdView;
+    receipts_outcome: ExecutionOutcomeWithIdView[];
 }

--- a/packages/frontend/src/services/coreIndexer/CoreIndexerAdapter.ts
+++ b/packages/frontend/src/services/coreIndexer/CoreIndexerAdapter.ts
@@ -6,6 +6,7 @@ import {
 import { FastNearIndexer } from './indexers/FastNearIndexer';
 import { NearblocksV3Indexer } from './indexers/NearblocksV3Indexer';
 import { MintbaseIndexer } from './indexers/MintbaseIndexer';
+import { MeteorBackendIndexer } from './indexers/MeteorBackendIndexer';
 import uniq from 'lodash.uniq';
 import CONFIG from '../../config';
 import { NftDetail } from './types/coreIndexer.type';
@@ -23,6 +24,7 @@ export class CoreIndexerAdapter {
             new FastNearIndexer(network),
             new NearblocksV3Indexer(network),
             new MintbaseIndexer(network),
+            new MeteorBackendIndexer(network),
         ];
         const supportedIndexers = indexers.filter((indexer) =>
             indexer.networkSupported.includes(network)
@@ -167,6 +169,20 @@ export class CoreIndexerAdapter {
                 .map((indexer) => indexer.getNftDetailByReference(referenceId))
         ).catch(() => {
             return {};
+        });
+    }
+
+    async getAccountTransactions(props): Promise<string[]> {
+        return await Promise.any(
+            this.indexersInQueue
+                .filter((indexer) =>
+                    indexer.methodsSupported.includes(
+                        E_CoreIndexerAvailableMethods.getAccountTransactions
+                    )
+                )
+                .map((indexer) => indexer.getAccountTransactions(props))
+        ).catch(() => {
+            return [];
         });
     }
 }

--- a/packages/frontend/src/services/coreIndexer/indexers/AbstractCoreIndexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/AbstractCoreIndexer.ts
@@ -21,6 +21,11 @@ export abstract class AbstractCoreIndexer {
     abstract getAccountValidatorList(accountId: string): Promise<string[]>;
     abstract getValidatorList(): Promise<string[]>;
     abstract getAccountNfts(accountId: string): Promise<string[]>;
+    abstract getAccountTransactions(props: {
+        accountId: string;
+        page: number;
+        pageSize: number;
+    }): Promise<string[]>;
     abstract getNftDetailByReference(referenceid: string): {};
 }
 
@@ -30,5 +35,6 @@ export enum E_CoreIndexerAvailableMethods {
     getAccountValidatorList = 'getAccountValidatorList',
     getValidatorList = 'getValidatorList',
     getAccountNfts = 'getAccountNfts',
+    getAccountTransactions = 'getAccountTransactions',
     getNftDetailByReference = 'getNftDetailByReference',
 }

--- a/packages/frontend/src/services/coreIndexer/indexers/FastNearIndexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/FastNearIndexer.ts
@@ -68,6 +68,10 @@ export class FastNearIndexer extends AbstractCoreIndexer {
     async getNftDetailByReference() {
         return {};
     }
+
+    async getAccountTransactions(): Promise<string[]> {
+        return [];
+    }
 }
 
 interface Response_getAccountIdListFromPublicKey {

--- a/packages/frontend/src/services/coreIndexer/indexers/MeteorBackendIndexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/MeteorBackendIndexer.ts
@@ -13,8 +13,7 @@ export class MeteorBackendIndexer extends AbstractCoreIndexer {
 
     protected getBaseUrl(): string {
         return this.network === ENearNetwork.mainnet
-            ? // ? 'https://backend-v2.meteorwallet.app/api/indexer'
-              'http://localhost:4000/api/indexer'
+            ? 'https://backend-v2.meteorwallet.app/api/indexer'
             : new NearblocksV1Indexer(ENearNetwork.testnet).getBaseUrl();
     }
 

--- a/packages/frontend/src/services/coreIndexer/indexers/MeteorBackendIndexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/MeteorBackendIndexer.ts
@@ -1,0 +1,75 @@
+import { ENearNetwork } from '@meteorwallet/meteor-near-sdk/dist/packages/common/core/modules/blockchains/near/core/types/near_basic_types';
+import {
+    AbstractCoreIndexer,
+    E_CoreIndexerAvailableMethods,
+} from './AbstractCoreIndexer';
+import { NearblocksV1Indexer } from './NearblocksV1Indexer';
+import { utils_pagination } from '../../../utils/pagination';
+
+export class MeteorBackendIndexer extends AbstractCoreIndexer {
+    networkSupported = [ENearNetwork.mainnet];
+    priority = 6;
+    methodsSupported = [E_CoreIndexerAvailableMethods.getAccountTransactions];
+
+    protected getBaseUrl(): string {
+        return this.network === ENearNetwork.mainnet
+            ? // ? 'https://backend-v2.meteorwallet.app/api/indexer'
+              'http://localhost:4000/api/indexer'
+            : new NearblocksV1Indexer(ENearNetwork.testnet).getBaseUrl();
+    }
+
+    getAccountIdListFromPublicKey(): Promise<string[]> {
+        throw new Error('Method not implemented.');
+    }
+
+    getAccountFtList(): Promise<string[]> {
+        throw new Error('Method not implemented.');
+    }
+
+    getAccountNftContractList(): Promise<string[]> {
+        throw new Error('Method not implemented.');
+    }
+
+    async getAccountTransactions({
+        accountId,
+        page,
+        pageSize,
+    }: {
+        accountId: string;
+        page: number;
+        pageSize: number;
+    }): Promise<string[]> {
+        const offset = utils_pagination.convertPageToOffset(page, pageSize);
+        const response = await fetch(`${this.getBaseUrl()}/get_transaction_hashes`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ accountId, offset, pageSize }),
+        });
+
+        if (!response.ok) {
+            throw new Error(
+                'Error: MeteorBackendIndexer failed to return account transactions'
+            );
+        }
+        const json = await response.json();
+        return json.value;
+    }
+
+    async getValidatorList(): Promise<string[]> {
+        return [];
+    }
+
+    async getAccountNfts(): Promise<string[]> {
+        return [];
+    }
+
+    async getNftDetailByReference() {
+        return {};
+    }
+
+    async getAccountValidatorList(): Promise<string[]> {
+        return [];
+    }
+}

--- a/packages/frontend/src/services/coreIndexer/indexers/MintbaseIndexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/MintbaseIndexer.ts
@@ -82,4 +82,8 @@ export class MintbaseIndexer extends AbstractCoreIndexer {
             ...meta.reference_blob,
         };
     }
+
+    async getAccountTransactions(): Promise<string[]> {
+        return [];
+    }
 }

--- a/packages/frontend/src/services/coreIndexer/indexers/NearblocksV1Indexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/NearblocksV1Indexer.ts
@@ -14,7 +14,7 @@ export class NearblocksV1Indexer extends AbstractCoreIndexer {
         E_CoreIndexerAvailableMethods.getAccountFtList,
     ];
 
-    protected getBaseUrl(): string {
+    getBaseUrl(): string {
         return this.network === ENearNetwork.mainnet
             ? 'https://api.nearblocks.io/v1'
             : 'https://api-testnet.nearblocks.io/v1';
@@ -78,6 +78,10 @@ export class NearblocksV1Indexer extends AbstractCoreIndexer {
 
     async getNftDetailByReference() {
         return {};
+    }
+
+    async getAccountTransactions(): Promise<string[]> {
+        return [];
     }
 }
 

--- a/packages/frontend/src/services/coreIndexer/indexers/NearblocksV3Indexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/NearblocksV3Indexer.ts
@@ -90,6 +90,10 @@ export class NearblocksV3Indexer extends AbstractCoreIndexer {
     async getNftDetailByReference() {
         return {};
     }
+
+    async getAccountTransactions(): Promise<string[]> {
+        return [];
+    }
 }
 
 interface I_getAccountIdListFromPublicKey_Output {

--- a/packages/frontend/src/utils/pagination.ts
+++ b/packages/frontend/src/utils/pagination.ts
@@ -1,0 +1,12 @@
+export function convertPageToOffset(page, pageSize) {
+    if (page < 1 || pageSize <= 0) {
+        return 0;
+    }
+
+    const offset = (page - 1) * pageSize;
+    return offset;
+}
+
+export const utils_pagination = {
+    convertPageToOffset,
+};

--- a/packages/frontend/src/utils/query/queryClient.ts
+++ b/packages/frontend/src/utils/query/queryClient.ts
@@ -30,5 +30,5 @@ persistQueryClient({
         restoreClient: localStoragePersister.restoreClient,
         removeClient: localStoragePersister.removeClient,
     },
-    maxAge: 1000 * 60 * 60 * 24 * 7, // 1 week
+    maxAge: 1000 * 60 * 60 * 24 * 30,
 });


### PR DESCRIPTION
## Issues
- Nearblocks reported that some users spammed the transaction history API more than 10,000 times.
Upon investigation, it was found that the "Load More" function in the Transaction History continues to hit Nearblocks when receiving error 429 (Too Many Requests). This happened on transaction history page infinite scroll
- The indexer's pagination limit return duplicated same transactions so we remove duplicate
- Some FT (received FT tokens) and NFT transactions are not included in a single API response. Currently, handling these cases requires using three separate APIs

## Changes description
- Migrate to meteor indexer
- Fix transaction subtitle ellipsis UI

Update from https://github.com/mynearwallet/my-near-wallet/pull/289
