### PR TITLE
fix: allow nonfunded account signmessage

### DIFF
--- a/packages/frontend/src/redux/slices/signMessage/index.js
+++ b/packages/frontend/src/redux/slices/signMessage/index.js
@@ -50,7 +50,7 @@ export const handleAuthorizationRequestConfirmed = createAsyncThunk(
                 callbackUrl,
             });
 
-            const signed = await wallet.signMessageAllowNonFundedAccount(
+            const signed = await wallet.signMessageAllowNonFundedAccountAndVerify(
                 encodedMessage,
                 accountId
             );

--- a/packages/frontend/src/redux/slices/signMessage/index.js
+++ b/packages/frontend/src/redux/slices/signMessage/index.js
@@ -50,7 +50,10 @@ export const handleAuthorizationRequestConfirmed = createAsyncThunk(
                 callbackUrl,
             });
 
-            const signed = await wallet.signMessage(encodedMessage, accountId);
+            const signed = await wallet.signMessageNonFundedAccount(
+                encodedMessage,
+                accountId
+            );
 
             if (signed.signed.publicKey.toString() !== publicKey.toString()) {
                 throw new Error(

--- a/packages/frontend/src/redux/slices/signMessage/index.js
+++ b/packages/frontend/src/redux/slices/signMessage/index.js
@@ -41,7 +41,7 @@ export const handleAuthorizationRequestConfirmed = createAsyncThunk(
         const { dispatch, getState } = thunkAPI;
         try {
             const accountId = selectAccountId(getState());
-            const publicKey = await wallet.getPublicKey(accountId);
+            const publicKey = await wallet.getPublicKeyAllowNonFundedAccount(accountId);
 
             const encodedMessage = messageToSign({
                 message,
@@ -50,7 +50,7 @@ export const handleAuthorizationRequestConfirmed = createAsyncThunk(
                 callbackUrl,
             });
 
-            const signed = await wallet.signMessageNonFundedAccount(
+            const signed = await wallet.signMessageAllowNonFundedAccount(
                 encodedMessage,
                 accountId
             );

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -1883,7 +1883,7 @@ export default class Wallet {
         };
     }
 
-    async signMessageAllowNonFundedAccount(message, accountId = this.accountId) {
+    async signMessageAllowNonFundedAccountAndVerify(message, accountId = this.accountId) {
         try {
             const account = await this.getAccount(accountId);
             const signer = account.signerIgnoringLedger || account.connection.signer;
@@ -1899,12 +1899,29 @@ export default class Wallet {
         } catch (err) {
             console.warn(err);
         }
+        const keyPair = await this.keyStore.getKey(CONFIG.NETWORK_ID, accountId);
+        if (!keyPair) {
+            throw new WalletError(
+                `No key found for account: ${accountId}`,
+                'getPublicKey.noKey'
+            );
+        }
+
         const signer = new nearApiJs.InMemorySigner(this.keyStore);
         const signed = await signer.signMessage(
             Buffer.from(message),
             accountId,
             CONFIG.NETWORK_ID
         );
+
+        const isValid = await keyPair.verify(Buffer.from(message), signed.signature);
+        if (!isValid) {
+            throw new WalletError(
+                'Ownership verification failed: Invalid key or accountId',
+                'signMessage.invalidSignature'
+            );
+        }
+
         return {
             accountId,
             signed,

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -1883,10 +1883,52 @@ export default class Wallet {
         };
     }
 
+    async signMessageAllowNonFundedAccount(message, accountId = this.accountId) {
+        try {
+            const account = await this.getAccount(accountId);
+            const signer = account.signerIgnoringLedger || account.connection.signer;
+            const signed = await signer.signMessage(
+                Buffer.from(message),
+                accountId,
+                CONFIG.NETWORK_ID
+            );
+            return {
+                accountId,
+                signed,
+            };
+        } catch (err) {
+            console.warn(err);
+        }
+        const signer = new nearApiJs.InMemorySigner(this.keyStore);
+        const signed = await signer.signMessage(
+            Buffer.from(message),
+            accountId,
+            CONFIG.NETWORK_ID
+        );
+        return {
+            accountId,
+            signed,
+        };
+    }
+
     async getPublicKey(accountId = this.accountId) {
-        const account = await this.getAccount(accountId);
-        const signer = account.signerIgnoringLedger || account.connection.signer;
-        return signer.getPublicKey(accountId, CONFIG.NETWORK_ID);
+        try {
+            const account = await this.getAccount(accountId);
+            const signer = account.signerIgnoringLedger || account.connection.signer;
+            return signer.getPublicKey(accountId, CONFIG.NETWORK_ID);
+        } catch (err) {
+            console.warn(err);
+        }
+
+        // if account not exist, using other way to get publickey
+        const keyPair = await this.keyStore.getKey(CONFIG.NETWORK_ID, accountId);
+        if (!keyPair) {
+            throw new WalletError(
+                `No key found for account: ${accountId}`,
+                'getPublicKey.noKey'
+            );
+        }
+        return keyPair.getPublicKey();
     }
 }
 

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -1912,6 +1912,12 @@ export default class Wallet {
     }
 
     async getPublicKey(accountId = this.accountId) {
+        const account = await this.getAccount(accountId);
+        const signer = account.signerIgnoringLedger || account.connection.signer;
+        return signer.getPublicKey(accountId, CONFIG.NETWORK_ID);
+    }
+
+    async getPublicKeyAllowNonFundedAccount(accountId = this.accountId) {
         try {
             const account = await this.getAccount(accountId);
             const signer = account.signerIgnoringLedger || account.connection.signer;


### PR DESCRIPTION
Background: 
Sign message does not require any deposit. Non-funded accounts should be able to sign messages

Changes Description:
- Funded account (Ledger / non-Ledger): Works using the same previous code 
- Non-funded implicit account: Works using the near-api-js verify function.
- Non-funded implicit account with Ledger: Will throw an error

<img width="522" alt="Screenshot 2025-04-10 at 10 26 17" src="https://github.com/user-attachments/assets/9def9825-6dc3-4bcd-a6ce-2120a43f912d" />

@race-of-sloths
