### PR TITLE
hotfix api error on create & import wallet

### DIFF
--- a/packages/frontend/src/redux/slices/account/createAccountThunks.js
+++ b/packages/frontend/src/redux/slices/account/createAccountThunks.js
@@ -44,10 +44,10 @@ export const addLocalKeyAndFinishSetup = createAsyncThunk(
             } else {
                 const contractName = null;
                 const fullAccess = true;
-                await wallet.postSignedJson('/account/seedPhraseAdded', {
-                    accountId,
-                    publicKey: publicKey.toString(),
-                });
+                // await wallet.postSignedJson('/account/seedPhraseAdded', {
+                //     accountId,
+                //     publicKey: publicKey.toString(),
+                // });
                 try {
                     await wallet.addAccessKey(
                         accountId,

--- a/packages/frontend/src/redux/slices/account/createAccountThunks.js
+++ b/packages/frontend/src/redux/slices/account/createAccountThunks.js
@@ -44,10 +44,14 @@ export const addLocalKeyAndFinishSetup = createAsyncThunk(
             } else {
                 const contractName = null;
                 const fullAccess = true;
-                // await wallet.postSignedJson('/account/seedPhraseAdded', {
-                //     accountId,
-                //     publicKey: publicKey.toString(),
-                // });
+                try {
+                    await wallet.postSignedJson('/account/seedPhraseAdded', {
+                        accountId,
+                        publicKey: publicKey.toString(),
+                    });
+                } catch (err) {
+                    console.log('error kitwallet /account/seedPhraseAdded');
+                }
                 try {
                     await wallet.addAccessKey(
                         accountId,

--- a/packages/frontend/src/services/coreIndexer/indexers/MintbaseIndexer.ts
+++ b/packages/frontend/src/services/coreIndexer/indexers/MintbaseIndexer.ts
@@ -12,10 +12,7 @@ import { NftMetadataResponse } from '../types/mintbaseIndexer.type';
 export class MintbaseIndexer extends AbstractCoreIndexer {
     networkSupported = [ENearNetwork.mainnet, ENearNetwork.testnet];
     priority = 3;
-    methodsSupported = [
-        E_CoreIndexerAvailableMethods.getAccountIdListFromPublicKey,
-        E_CoreIndexerAvailableMethods.getNftDetailByReference,
-    ];
+    methodsSupported = [E_CoreIndexerAvailableMethods.getNftDetailByReference];
     gqlClient = new GraphQLClient(this.getBaseUrl(), {
         headers: {
             'content-type': 'application/json',
@@ -41,7 +38,7 @@ export class MintbaseIndexer extends AbstractCoreIndexer {
         if (error || !data || data.length === 0) {
             console.error(error);
             throw new Error(
-                `Error: FastNear failed to capture account fungible token list for account id: ${publicKey}`
+                `Error: Mintbase failed to capture account fungible token list for account id: ${publicKey}`
             );
         }
         return data;

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -1127,7 +1127,7 @@ export default class Wallet {
 
         let accountIds;
         try {
-            const waitAllIndexer = true;
+            const waitAllIndexer = false;
             accountIds = await getAccountIds(publicKey, waitAllIndexer);
         } catch (error) {
             if (error.name === 'AbortError') {


### PR DESCRIPTION
## Changes description
- Fixed Import Wallet Timeout Issue: 
Importing wallets often timed out on the indexer https://interop-testnet.hasura.app/v1/graphql, causing users to wait more than 60 seconds to see results. This issue was resolved by removing it, as other indexers already handle it, and make the fetching return the first successfull one
- Resolved Create Wallet Error: 
Fixed an error encountered during wallet creation: `UnrecognizedClientException: The security token included in the request is invalid` on the https://helper.mainnet.near.org/ API by trycatch non critical api hit