### PR TITLE
fix: add fallback redirect for window opener conflict after sign dapps

### DIFF
--- a/packages/frontend/src/components/login/v2/SelectAccountLoginWrapper.js
+++ b/packages/frontend/src/components/login/v2/SelectAccountLoginWrapper.js
@@ -58,6 +58,9 @@ export default ({
                 Mixpanel.track('LOGIN Click deny button');
                 if (failureUrl && failureAndSuccessUrlsAreValid) {
                     if (window.opener) {
+                        setTimeout(() => {
+                            window.location.href = failureUrl;
+                        }, 3000);
                         return window.opener.postMessage(
                             {
                                 status: 'failure',

--- a/packages/frontend/src/routes/SignMessageWrapper.js
+++ b/packages/frontend/src/routes/SignMessageWrapper.js
@@ -53,6 +53,18 @@ const SignMessageWrapper = () => {
     useEffect(() => {
         if (verifyOwnerStatus === SIGN_MESSAGE_STATUS.COMPLETED) {
             if (window.opener) {
+                setTimeout(() => {
+                    if (accountUrlCallbackUrl && isValidCallbackUrl) {
+                        window.location.href = buildRedirectUrl(
+                            accountUrlCallbackUrl,
+                            signedRequest,
+                            accountUrlState,
+                            verifyOwnerError
+                        );
+                    } else {
+                        dispatch(redirectTo('/'));
+                    }
+                }, 3000);
                 return window.opener.postMessage(
                     {
                         status: 'success',


### PR DESCRIPTION
Background: Some users experience issues when signing transactions on dApps. The button keeps showing a loading state without redirecting, even though the transaction has already gone through
<img width="494" alt="Screenshot 2025-05-28 at 10 49 08" src="https://github.com/user-attachments/assets/f57dac3a-70fe-4ab9-b323-dadac413ccba" />

Findings: This issue occurs only with dApps using Wallet Selector < 9 and when users have installed certain browser extensions that interfere with the window opener

Fixes: Add a fallback redirect in case the issue is caused by an unintended interference with window.opener, such as by a browser extension
