### PR TITLE
fix: custom added rpc should update on reload, add fastnear testnet

### DIFF
--- a/packages/frontend/src/utils/mnw-api-js/src/RpcRotator.ts
+++ b/packages/frontend/src/utils/mnw-api-js/src/RpcRotator.ts
@@ -100,17 +100,6 @@ const testnetRpcOptionList: RpcOption[] = [
     //     }),
     // },
     {
-        id: 'infura-testnet',
-        defaultParams: {
-            url: 'https://near-testnet.infura.io/v3/API-KEY',
-        },
-        userParams: ['apiKey'],
-        generator: ({ url, headers, apiKey }) => ({
-            url: url.replace('API-KEY', apiKey),
-            headers,
-        }),
-    },
-    {
         id: 'lava-testnet',
         userParams: ['url', 'headers'],
         generator: ({ url, headers }) => ({

--- a/packages/frontend/src/utils/mnw-api-js/src/RpcRotator.ts
+++ b/packages/frontend/src/utils/mnw-api-js/src/RpcRotator.ts
@@ -34,6 +34,11 @@ const mainnetRpcOptionList: RpcOption[] = [
         defaultParams: {
             url: 'https://rpc.ankr.com/near/',
         },
+        userParams: ['apiKey'],
+        generator: ({ url, headers, apiKey }) => ({
+            url: url.replace('<api_key>', apiKey),
+            headers: headers,
+        }),
     },
     {
         id: 'getBlock',

--- a/packages/frontend/src/utils/storage/src/ConnectionsStorage.ts
+++ b/packages/frontend/src/utils/storage/src/ConnectionsStorage.ts
@@ -63,6 +63,14 @@ const testnetConnections = [
         },
         priority: 10,
     },
+    {
+        id: 'fastnear-testnet',
+        label: 'Fastnear Rpc',
+        data: {
+            url: 'https://test.rpc.fastnear.com',
+        },
+        priority: 11,
+    },
 ];
 
 export const defaultConnections = CONFIG.NEAR_WALLET_ENV.startsWith('mainnet')

--- a/packages/frontend/src/utils/storage/src/ConnectionsStorage.ts
+++ b/packages/frontend/src/utils/storage/src/ConnectionsStorage.ts
@@ -57,7 +57,7 @@ const mainnetConnections = [
 const testnetConnections = [
     {
         id: 'near-testnet',
-        label: 'Default Connection',
+        label: 'Official Near Testnet Rpc',
         data: {
             url: 'https://rpc.testnet.near.org',
         },
@@ -65,7 +65,7 @@ const testnetConnections = [
     },
     {
         id: 'fastnear-testnet',
-        label: 'Fastnear Rpc',
+        label: 'Fastnear Testnet Rpc',
         data: {
             url: 'https://test.rpc.fastnear.com',
         },

--- a/packages/frontend/src/utils/storage/src/ObjectStorage.ts
+++ b/packages/frontend/src/utils/storage/src/ObjectStorage.ts
@@ -11,9 +11,14 @@ export abstract class ObjectStorage<DataType> extends BaseStorage<DataType> {
             const storedString = this.storage.getItem(this.storageKey);
 
             if (storedString && this.storageKey === 'connections') {
-                // reset connection cache when no connections
+                // Reset connection cache for users returning to the site from before the default connections selector feature was introduced
                 const storedConnections = JSON.parse(storedString) as IRpcConnection[];
-                if (!storedConnections.length) {
+                const defaultConnections = this.default as IRpcConnection[];
+                // Only reset if stored connections do NOT contain all default connections (legacy users)
+                const isLegacy = !defaultConnections.every((def) =>
+                    storedConnections.some((conn) => conn.id === def.id)
+                );
+                if (isLegacy) {
                     return this.default;
                 }
                 return storedConnections as DataType;

--- a/packages/frontend/src/utils/storage/src/ObjectStorage.ts
+++ b/packages/frontend/src/utils/storage/src/ObjectStorage.ts
@@ -11,11 +11,9 @@ export abstract class ObjectStorage<DataType> extends BaseStorage<DataType> {
             const storedString = this.storage.getItem(this.storageKey);
 
             if (storedString && this.storageKey === 'connections') {
-                // reset connection cache when there is update
+                // reset connection cache when no connections
                 const storedConnections = JSON.parse(storedString) as IRpcConnection[];
-                if (
-                    storedConnections.length !== (this.default as IRpcConnection[]).length
-                ) {
+                if (!storedConnections.length) {
                     return this.default;
                 }
                 return storedConnections as DataType;


### PR DESCRIPTION
## Issues
Added custom RPC is not saved when the page is reloaded.

## Changes description
- Fixed: Custom-added RPC now retains its state after a page reload
- Added: Fastnear RPC for testnet
- Updated: Ankr RPC on mainnet now requires an API key
- Remove: Infura RPC for the testnet no longer exists

## Tested
- Add custom RPC
- Switch primary RPC
- Legacy users with old RPC connections should have the newly added RPC connections included
- Should return the default RPC list for new users (incognito browser).
