### PR TITLE
fix: staking testnet page not loaded

### DIFF
--- a/packages/frontend/src/utils/account-with-lockup.ts
+++ b/packages/frontend/src/utils/account-with-lockup.ts
@@ -249,6 +249,9 @@ async function getAccountBalance(limitedAccountData = false) {
                     .catch((err) => {
                         if (
                             // Means the validators  don't have contract deployed, or don't support staking
+                            err.message.includes(
+                                'CompilationError(PrepareError(Deserialization))'
+                            ) ||
                             err.message.includes('CompilationError(CodeDoesNotExist') ||
                             err.message.includes('MethodResolveError(MethodNotFound)')
                         ) {

--- a/packages/frontend/src/utils/staking.ts
+++ b/packages/frontend/src/utils/staking.ts
@@ -97,6 +97,9 @@ export async function getStakingDeposits(accountId: string) {
                 .catch((err) => {
                     if (
                         // Means the validators  don't have contract deployed, or don't support staking
+                        err.message.includes(
+                            'CompilationError(PrepareError(Deserialization))'
+                        ) ||
                         err.message.includes('CompilationError(CodeDoesNotExist') ||
                         err.message.includes('MethodResolveError(MethodNotFound)')
                     ) {


### PR DESCRIPTION
## Issues
Some validators on testnet throw the error CompilationError(PrepareError(Deserialization)) when calling the get_account_total_balance method. This indicates the validator do not support staking, which causes the staking page to fail to load (e.g., node0). On the Staking page, it retrieves all epochValidatorInfo validators, including current_proposals, next_validators, and prev_epoch_kickout

## Changes description
Fix: Catch Deserialization errors on the staking page to prevent them from blocking the page
