### PR TITLE
fix: some token not showing usd price

### DIFF
--- a/packages/frontend/src/config/environmentDefaults/mainnet.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet.ts
@@ -60,7 +60,7 @@ export default {
     NEAR_TOKEN_ID: 'wrap.near',
     FARMING_CLAIM_GAS: parseNearAmount('0.00000000015'),
     FARMING_CLAIM_YOCTO: '1',
-    REF_FINANCE_API_ENDPOINT: 'https://indexer.ref.finance',
+    REF_FINANCE_API_ENDPOINT: 'https://api.ref.finance',
     REF_FINANCE_CONTRACT: 'v2.ref-finance.near',
     USN_CONTRACT: 'usn',
     USDT_CONTRACT: 'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near',

--- a/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
+++ b/packages/frontend/src/config/environmentDefaults/mainnet_STAGING.ts
@@ -60,7 +60,7 @@ export default {
     NEAR_TOKEN_ID: 'wrap.near',
     FARMING_CLAIM_GAS: parseNearAmount('0.00000000015'),
     FARMING_CLAIM_YOCTO: '1',
-    REF_FINANCE_API_ENDPOINT: 'https://indexer.ref.finance',
+    REF_FINANCE_API_ENDPOINT: 'https://api.ref.finance',
     REF_FINANCE_CONTRACT: 'v2.ref-finance.near',
     USN_CONTRACT: 'usn',
     USDT_CONTRACT: 'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near',


### PR DESCRIPTION
## Changes description
Fixed an issue where the USD price of some new tokens, such as RHEA, was not displaying due to an outdated API

<img width="1191" height="494" alt="Screenshot 2025-07-31 at 17 47 14" src="https://github.com/user-attachments/assets/a3b8c52f-ce0d-49e2-9d52-8190c92458d3" />
