### PR TITLE
fix ledger near app 2.3.5 signmessage

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,6 @@
         "big.js": "^6.2.1",
         "bip39-light": "^1.0.7",
         "borsh": "1.0.0",
-        "borsher": "3.5.0",
         "calimero-wallet-utils": "^0.0.1",
         "connected-react-router": "^6.6.0",
         "dataloader": "^2.1.0",

--- a/packages/frontend/src/utils/signMessage.ts
+++ b/packages/frontend/src/utils/signMessage.ts
@@ -1,15 +1,16 @@
-import { BorshSchema, borshSerialize } from 'borsher';
+import * as borsh from 'borsh';
 
 //
 // https://github.com/near/NEPs/blob/master/neps/nep-0413.md
 //
-
-export const messageNep413BorshSchema = BorshSchema.Struct({
-    message: BorshSchema.String,
-    nonce: BorshSchema.Array(BorshSchema.u8, 32),
-    recipient: BorshSchema.String,
-    callbackUrl: BorshSchema.Option(BorshSchema.String),
-});
+const schema = {
+    struct: {
+        message: 'string',
+        nonce: { array: { type: 'u8', len: 32 } },
+        recipient: 'string',
+        callbackUrl: { option: 'string' },
+    },
+};
 
 const isBase64 = (value: string) =>
     /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$/.test(
@@ -23,6 +24,9 @@ export const validateNonce = (nonce?: string) => {
     return nonce && nonce.length === 32;
 };
 
+export const serialize = (value) => borsh.serialize(schema, value);
+export const deserialize = (value) => borsh.deserialize(schema, value);
+
 export const messageToSign = (data: {
     message: string;
     nonce: string;
@@ -33,10 +37,9 @@ export const messageToSign = (data: {
         ? Buffer.from(data.nonce, 'base64')
         : Buffer.from(data.nonce);
     const payload = {
-        tag: 2147484061,
         ...data,
         nonce,
     };
 
-    return borshSerialize(messageNep413BorshSchema, payload);
+    return serialize(payload);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6141,19 +6141,6 @@ borsh@1.0.0:
   resolved "https://registry.yarnpkg.com/borsh/-/borsh-1.0.0.tgz#b564c8cc8f7a91e3772b9aef9e07f62b84213c1f"
   integrity sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==
 
-borsh@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/borsh/-/borsh-2.0.0.tgz#042a9f109565caac3c6a21297cd8c0ae8db3149d"
-  integrity sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==
-
-borsher@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/borsher/-/borsher-3.5.0.tgz#cf7f73a00decf3aeae70944e4e68f93789afb383"
-  integrity sha512-53UlE2ukArKGrw3u+MKR5CBqYR+Fr47tGAeIRmAy+W5G6FMRnoM7G8mHYFeijGyhKje5aaQTCqZu/hugQ2HiBA==
-  dependencies:
-    borsh "^2.0.0"
-    buffer "^6.0.3"
-
 bplist-parser@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.2.0.tgz#43a9d183e5bf9d545200ceac3e712f79ebbe8d0e"


### PR DESCRIPTION
User reported an error when signing a message with Ledger:
Ownership verification failed: Invalid key or accountId

The actual error from Ledger was:
Ledger device: UNKNOWN_ERROR (0xb005)

This has now been fixed to throw the direct error from Ledger.

After investigation, the issue was caused by the tag added to the payload not a valid NEP-413 format
Fixes applied:
- Instruction to Ledger is set to 7, which means it signs for NEP-413, previously 2 (regular sign)
- Users are required to update the NEAR app if they want to use signMessage.

Tested on Ledger NEAR app version 2.3.5.
Followup fix on https://github.com/mynearwallet/my-near-wallet/pull/310