### PR TITLE
revert tag payload on sign message for non ledger

### DIFF
--- a/packages/frontend/src/redux/slices/signMessage/index.js
+++ b/packages/frontend/src/redux/slices/signMessage/index.js
@@ -43,16 +43,21 @@ export const handleAuthorizationRequestConfirmed = createAsyncThunk(
             const accountId = selectAccountId(getState());
             const publicKey = await wallet.getPublicKeyAllowNonFundedAccount(accountId);
 
-            const encodedMessage = messageToSign({
-                message,
-                nonce,
-                recipient,
-                callbackUrl,
-            });
+            const isLedger = !!(await wallet.getLedgerKey(accountId));
+            const encodedMessage = messageToSign(
+                {
+                    message,
+                    nonce,
+                    recipient,
+                    callbackUrl,
+                },
+                isLedger
+            );
 
             const signed = await wallet.signMessageAllowNonFundedAccountAndVerify(
                 encodedMessage,
-                accountId
+                accountId,
+                isLedger
             );
 
             if (signed.signed.publicKey.toString() !== publicKey.toString()) {

--- a/packages/frontend/src/utils/signMessage.ts
+++ b/packages/frontend/src/utils/signMessage.ts
@@ -3,14 +3,6 @@ import * as borsh from 'borsh';
 //
 // https://github.com/near/NEPs/blob/master/neps/nep-0413.md
 //
-const schema = {
-    struct: {
-        message: 'string',
-        nonce: { array: { type: 'u8', len: 32 } },
-        recipient: 'string',
-        callbackUrl: { option: 'string' },
-    },
-};
 
 const isBase64 = (value: string) =>
     /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$/.test(
@@ -24,22 +16,53 @@ export const validateNonce = (nonce?: string) => {
     return nonce && nonce.length === 32;
 };
 
-export const serialize = (value) => borsh.serialize(schema, value);
-export const deserialize = (value) => borsh.deserialize(schema, value);
-
-export const messageToSign = (data: {
-    message: string;
-    nonce: string;
-    recipient: string;
-    callbackUrl?: string;
-}) => {
+export const messageToSign = (
+    data: {
+        message: string;
+        nonce: string;
+        recipient: string;
+        callbackUrl?: string;
+    },
+    isLedger: boolean
+) => {
     const nonce = isBase64(data.nonce)
         ? Buffer.from(data.nonce, 'base64')
         : Buffer.from(data.nonce);
-    const payload = {
-        ...data,
-        nonce,
-    };
+    if (isLedger) {
+        const payload = {
+            ...data,
+            nonce,
+        };
 
-    return serialize(payload);
+        return borsh.serialize(
+            {
+                struct: {
+                    message: 'string',
+                    nonce: { array: { type: 'u8', len: 32 } },
+                    recipient: 'string',
+                    callbackUrl: { option: 'string' },
+                },
+            },
+            payload
+        );
+    } else {
+        const payload = {
+            tag: 2147484061,
+            ...data,
+            nonce,
+        };
+
+        return borsh.serialize(
+            {
+                struct: {
+                    tag: 'u32',
+                    message: 'string',
+                    nonce: { array: { type: 'u8', len: 32 } },
+                    recipient: 'string',
+                    callbackUrl: { option: 'string' },
+                },
+            },
+            payload
+        );
+    }
 };

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -1883,15 +1883,25 @@ export default class Wallet {
         };
     }
 
-    async signMessageAllowNonFundedAccountAndVerify(message, accountId = this.accountId) {
+    async signMessageAllowNonFundedAccountAndVerify(
+        message,
+        accountId = this.accountId,
+        isLedger
+    ) {
         try {
             const account = await this.getAccount(accountId);
             const signer = account.signerIgnoringLedger || account.connection.signer;
             const signed = await signer.signMessage(
-                Buffer.from(message),
+                isLedger
+                    ? new Uint8Array(
+                          message.buffer,
+                          message.byteOffset,
+                          message.byteLength
+                      )
+                    : Buffer.from(message),
                 accountId,
                 CONFIG.NETWORK_ID,
-                true
+                isLedger
             );
             return {
                 accountId,


### PR DESCRIPTION
Update from https://github.com/mynearwallet/my-near-wallet/pull/310
Some apps are unable to verify message.
This update reverts to the old signMessage payload (with the tag payload) for non-Ledger users.
For Ledger users use NEP-413, as required by the Ledger NEAR app (without the tag payload).
