### PR TITLE
fix: should complete actions from near-connect and listen to query param

### DIFF
--- a/packages/frontend/src/app/App.js
+++ b/packages/frontend/src/app/App.js
@@ -90,7 +90,7 @@ import translations_vi from '../translations/locales/vi/translation.json';
 import translations_zh_hans from '../translations/locales/zh-hans/translation.json';
 import translations_zh_hant from '../translations/locales/zh-hant/translation.json';
 import classNames from '../utils/classNames';
-import { saveState } from '../utils/sessionStorage';
+import { saveState, loadState, clearState } from '../utils/sessionStorage';
 import getBrowserLocale from '../utils/getBrowserLocale';
 import { reportUiActiveMixpanelThrottled } from '../utils/reportUiActiveMixpanelThrottled';
 import ScrollToTop from '../utils/ScrollToTop';
@@ -105,7 +105,6 @@ import {
 } from '../utils/wallet';
 import TransactionExecutorModal from '../components/transactions/ExecutorModal/TransactionExecutorModal';
 import LiquidStakingContainer from '../components/staking/liquid-staking/LiquidStakingContainer';
-import { session_storage_key } from '../utils/storage/session_storage_key.constant';
 
 const { getTokenWhiteList } = tokenFiatValueActions;
 
@@ -181,10 +180,6 @@ class Routing extends Component {
                     redirect_url: routerLocation.pathname,
                 };
                 saveState(dappParams);
-                sessionStorage.setItem(
-                    session_storage_key.PENDING_DAPP_REDIRECT,
-                    JSON.stringify(dappParams)
-                );
             }
         }
 
@@ -288,17 +283,14 @@ class Routing extends Component {
             prevProps.account.accountId !== account.accountId &&
             account.accountId !== undefined
         ) {
-            const pendingRedirect = JSON.parse(
-                sessionStorage.getItem(session_storage_key.PENDING_DAPP_REDIRECT) ||
-                    'null'
-            );
+            const pendingRedirect = loadState();
             if (
                 !prevProps.account.accountId &&
                 pendingRedirect &&
                 pendingRedirect.redirect_url &&
                 pendingRedirect.redirect_url !== '/'
             ) {
-                sessionStorage.removeItem(session_storage_key.PENDING_DAPP_REDIRECT);
+                clearState();
                 this.props.history.push({
                     pathname: pendingRedirect.redirect_url,
                     search: `?${stringify(pendingRedirect)}`,

--- a/packages/frontend/src/app/App.js
+++ b/packages/frontend/src/app/App.js
@@ -2,7 +2,7 @@ import { ConnectedRouter, getRouter } from 'connected-react-router';
 import isString from 'lodash.isstring';
 import { parseSeedPhrase } from 'near-seed-phrase';
 import PropTypes from 'prop-types';
-import { stringify } from 'query-string';
+import { parse, stringify } from 'query-string';
 import React, { Component } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { withLocalize } from 'react-localize-redux';
@@ -90,17 +90,22 @@ import translations_vi from '../translations/locales/vi/translation.json';
 import translations_zh_hans from '../translations/locales/zh-hans/translation.json';
 import translations_zh_hant from '../translations/locales/zh-hant/translation.json';
 import classNames from '../utils/classNames';
+import { saveState } from '../utils/sessionStorage';
 import getBrowserLocale from '../utils/getBrowserLocale';
 import { reportUiActiveMixpanelThrottled } from '../utils/reportUiActiveMixpanelThrottled';
 import ScrollToTop from '../utils/ScrollToTop';
 import {
+    KEY_ACTIVE_ACCOUNT_ID,
     WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS,
     WALLET_LOGIN_URL,
-    WALLET_SIGN_URL,
     WALLET_SEND_MONEY_URL,
+    WALLET_SIGN_MESSAGE_URL,
+    WALLET_SIGN_URL,
+    WALLET_VERIFY_OWNER_URL,
 } from '../utils/wallet';
 import TransactionExecutorModal from '../components/transactions/ExecutorModal/TransactionExecutorModal';
 import LiquidStakingContainer from '../components/staking/liquid-staking/LiquidStakingContainer';
+import { session_storage_key } from '../utils/storage/session_storage_key.constant';
 
 const { getTokenWhiteList } = tokenFiatValueActions;
 
@@ -156,6 +161,32 @@ const Container = styled.div`
 class Routing extends Component {
     constructor(props) {
         super(props);
+
+        // Save dApp URL params before PrivateRoute redirects to /
+        const routerLocation = this.props.router?.location;
+        if (routerLocation) {
+            const page = routerLocation.pathname.split('/')[1];
+            if (
+                [
+                    WALLET_LOGIN_URL,
+                    WALLET_SIGN_URL,
+                    WALLET_SIGN_MESSAGE_URL,
+                    WALLET_VERIFY_OWNER_URL,
+                ].includes(page) &&
+                routerLocation.search &&
+                !localStorage.getItem(KEY_ACTIVE_ACCOUNT_ID)
+            ) {
+                const dappParams = {
+                    ...parse(routerLocation.search),
+                    redirect_url: routerLocation.pathname,
+                };
+                saveState(dappParams);
+                sessionStorage.setItem(
+                    session_storage_key.PENDING_DAPP_REDIRECT,
+                    JSON.stringify(dappParams)
+                );
+            }
+        }
 
         this.pollTokenFiatValue = null;
 
@@ -257,6 +288,26 @@ class Routing extends Component {
             prevProps.account.accountId !== account.accountId &&
             account.accountId !== undefined
         ) {
+            const pendingRedirect = JSON.parse(
+                sessionStorage.getItem(session_storage_key.PENDING_DAPP_REDIRECT) ||
+                    'null'
+            );
+            if (
+                !prevProps.account.accountId &&
+                pendingRedirect &&
+                pendingRedirect.redirect_url &&
+                pendingRedirect.redirect_url !== '/'
+            ) {
+                sessionStorage.removeItem(session_storage_key.PENDING_DAPP_REDIRECT);
+                this.props.history.push({
+                    pathname: pendingRedirect.redirect_url,
+                    search: `?${stringify(pendingRedirect)}`,
+                    state: { globalAlertPreventClear: true },
+                });
+                this.props.handleRefreshUrl();
+                return;
+            }
+
             this.props.getTokenWhiteList(account.accountId);
         }
 

--- a/packages/frontend/src/components/accounts/RecoverAccountPrivateKey.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountPrivateKey.js
@@ -1,6 +1,6 @@
 import { KeyPair } from 'near-api-js';
 import { parse as parseQuery, stringify } from 'query-string';
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Translate } from 'react-localize-redux';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
@@ -30,6 +30,7 @@ import ModalManualImportWithButton from './manual_import/ModalManualImportWithBu
 import { EWalletImportInputType } from './manual_import/type';
 import VerifyWalletDomainBanner from '../common/VerifyWalletDomainBanner';
 import SelectAccountImport from './ledger/SelectAccountImport';
+import { session_storage_key } from '../../utils/storage/session_storage_key.constant';
 
 const { setZeroBalanceAccountImportMethod } = importZeroBalanceAccountActions;
 
@@ -58,12 +59,19 @@ const RecoverAccountPrivateKey = () => {
     const [privateKey, setPrivateKey] = useState('');
     const [recoveringAccount, setRecoveringAccount] = useState(false);
     const [accountIdsSuccess, setAccountIdsSuccess] = useState([]);
+    const pendingRedirectRef = useRef(null);
     const localAlert = useSelector(selectStatusLocalAlert);
     const location = useLocation();
     const dispatch = useDispatch();
 
     const handleSubmit = async (e) => {
         e.preventDefault();
+
+        // Capture to avoid pending redirect race conditions
+        pendingRedirectRef.current = JSON.parse(
+            sessionStorage.getItem(session_storage_key.PENDING_DAPP_REDIRECT) || 'null'
+        );
+
         try {
             KeyPair.fromString(privateKey);
         } catch (err) {
@@ -138,7 +146,26 @@ const RecoverAccountPrivateKey = () => {
                     )
                 );
             } else if (withRedirectToApp) {
-                dispatch(redirectToApp('/'));
+                const pendingRedirect =
+                    pendingRedirectRef.current ||
+                    JSON.parse(
+                        sessionStorage.getItem(
+                            session_storage_key.PENDING_DAPP_REDIRECT
+                        ) || 'null'
+                    );
+
+                if (pendingRedirect && pendingRedirect.redirect_url) {
+                    dispatch(
+                        redirectTo(
+                            `${pendingRedirect.redirect_url}?${stringify(
+                                pendingRedirect
+                            )}`,
+                            { globalAlertPreventClear: true }
+                        )
+                    );
+                } else {
+                    dispatch(redirectToApp('/'));
+                }
             }
         }
     }

--- a/packages/frontend/src/components/accounts/RecoverAccountPrivateKey.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountPrivateKey.js
@@ -30,7 +30,7 @@ import ModalManualImportWithButton from './manual_import/ModalManualImportWithBu
 import { EWalletImportInputType } from './manual_import/type';
 import VerifyWalletDomainBanner from '../common/VerifyWalletDomainBanner';
 import SelectAccountImport from './ledger/SelectAccountImport';
-import { session_storage_key } from '../../utils/storage/session_storage_key.constant';
+import { loadState } from '../../utils/sessionStorage';
 
 const { setZeroBalanceAccountImportMethod } = importZeroBalanceAccountActions;
 
@@ -68,9 +68,7 @@ const RecoverAccountPrivateKey = () => {
         e.preventDefault();
 
         // Capture to avoid pending redirect race conditions
-        pendingRedirectRef.current = JSON.parse(
-            sessionStorage.getItem(session_storage_key.PENDING_DAPP_REDIRECT) || 'null'
-        );
+        pendingRedirectRef.current = loadState();
 
         try {
             KeyPair.fromString(privateKey);
@@ -146,13 +144,7 @@ const RecoverAccountPrivateKey = () => {
                     )
                 );
             } else if (withRedirectToApp) {
-                const pendingRedirect =
-                    pendingRedirectRef.current ||
-                    JSON.parse(
-                        sessionStorage.getItem(
-                            session_storage_key.PENDING_DAPP_REDIRECT
-                        ) || 'null'
-                    );
+                const pendingRedirect = pendingRedirectRef.current || loadState();
 
                 if (pendingRedirect && pendingRedirect.redirect_url) {
                     dispatch(

--- a/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -35,7 +35,7 @@ import ModalManualImportWithButton from './manual_import/ModalManualImportWithBu
 import { EWalletImportInputType } from './manual_import/type';
 import VerifyWalletDomainBanner from '../common/VerifyWalletDomainBanner';
 import SelectAccountImport from './ledger/SelectAccountImport';
-import { session_storage_key } from '../../utils/storage/session_storage_key.constant';
+import { loadState } from '../../utils/sessionStorage';
 
 const { setZeroBalanceAccountImportMethod } = importZeroBalanceAccountActions;
 
@@ -93,9 +93,7 @@ class RecoverAccountSeedPhrase extends Component {
             return false;
         }
 
-        this.pendingRedirect = JSON.parse(
-            sessionStorage.getItem(session_storage_key.PENDING_DAPP_REDIRECT) || 'null'
-        );
+        this.pendingRedirect = loadState();
 
         const { seedPhrase } = this.state;
         const {
@@ -184,13 +182,7 @@ class RecoverAccountSeedPhrase extends Component {
                     `/linkdrop/${options.fundingContract}/${options.fundingKey}${redirectUrl}`
                 );
             } else if (withRedirectToApp) {
-                const pendingRedirect =
-                    this.pendingRedirect ||
-                    JSON.parse(
-                        sessionStorage.getItem(
-                            session_storage_key.PENDING_DAPP_REDIRECT
-                        ) || 'null'
-                    );
+                const pendingRedirect = this.pendingRedirect || loadState();
 
                 if (pendingRedirect && pendingRedirect.redirect_url) {
                     this.props.history.push({

--- a/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
+++ b/packages/frontend/src/components/accounts/RecoverAccountSeedPhrase.js
@@ -35,6 +35,7 @@ import ModalManualImportWithButton from './manual_import/ModalManualImportWithBu
 import { EWalletImportInputType } from './manual_import/type';
 import VerifyWalletDomainBanner from '../common/VerifyWalletDomainBanner';
 import SelectAccountImport from './ledger/SelectAccountImport';
+import { session_storage_key } from '../../utils/storage/session_storage_key.constant';
 
 const { setZeroBalanceAccountImportMethod } = importZeroBalanceAccountActions;
 
@@ -91,6 +92,10 @@ class RecoverAccountSeedPhrase extends Component {
             Mixpanel.track('IE-SP Recover seed phrase link not valid');
             return false;
         }
+
+        this.pendingRedirect = JSON.parse(
+            sessionStorage.getItem(session_storage_key.PENDING_DAPP_REDIRECT) || 'null'
+        );
 
         const { seedPhrase } = this.state;
         const {
@@ -179,7 +184,23 @@ class RecoverAccountSeedPhrase extends Component {
                     `/linkdrop/${options.fundingContract}/${options.fundingKey}${redirectUrl}`
                 );
             } else if (withRedirectToApp) {
-                redirectToApp('/');
+                const pendingRedirect =
+                    this.pendingRedirect ||
+                    JSON.parse(
+                        sessionStorage.getItem(
+                            session_storage_key.PENDING_DAPP_REDIRECT
+                        ) || 'null'
+                    );
+
+                if (pendingRedirect && pendingRedirect.redirect_url) {
+                    this.props.history.push({
+                        pathname: pendingRedirect.redirect_url,
+                        search: `?${stringify(pendingRedirect)}`,
+                        state: { globalAlertPreventClear: true },
+                    });
+                } else {
+                    redirectToApp('/');
+                }
             }
         }
     }

--- a/packages/frontend/src/components/sign-message/SignMessage.js
+++ b/packages/frontend/src/components/sign-message/SignMessage.js
@@ -65,6 +65,7 @@ const StyledContainer = styled.div`
             text-align: justify;
             text-color: #272729;
             margin: 0 12px 12px 12px;
+            word-wrap: break-word;
         }
     }
 

--- a/packages/frontend/src/components/verify-owner/VerifyOwner.js
+++ b/packages/frontend/src/components/verify-owner/VerifyOwner.js
@@ -55,6 +55,7 @@ const StyledContainer = styled.div`
             text-align: justify;
             text-color: #272729;
             margin: 0 12px 12px 12px;
+            word-wrap: break-word;
         }
     }
 

--- a/packages/frontend/src/routes/SetupPassphraseNewAccountWrapper.js
+++ b/packages/frontend/src/routes/SetupPassphraseNewAccountWrapper.js
@@ -1,8 +1,10 @@
 import React, { useCallback } from 'react';
+import { stringify } from 'query-string';
 import { useDispatch } from 'react-redux';
 
 import SetupPassphraseNewAccount from '../components/accounts/recovery_setup/new_account/SetupPassphraseNewAccount';
 import { redirectTo } from '../redux/actions/account';
+import { loadState, saveState, clearState } from '../utils/sessionStorage';
 import { initiateSetupForZeroBalanceAccountPhrase } from '../redux/slices/account/createAccountThunks';
 
 const SetupPassphraseNewAccountWrapper = () => {
@@ -10,13 +12,27 @@ const SetupPassphraseNewAccountWrapper = () => {
 
     const handleConfirmPassphrase = useCallback(
         async ({ implicitAccountId, recoveryKeyPair }) => {
+            const pendingRedirect = loadState();
+
             await dispatch(
                 initiateSetupForZeroBalanceAccountPhrase({
                     implicitAccountId,
                     recoveryKeyPair,
                 })
             );
-            dispatch(redirectTo('/'));
+
+            if (pendingRedirect && pendingRedirect.redirect_url) {
+                clearState();
+                saveState(pendingRedirect);
+                dispatch(
+                    redirectTo(
+                        `${pendingRedirect.redirect_url}?${stringify(pendingRedirect)}`,
+                        { globalAlertPreventClear: true }
+                    )
+                );
+            } else {
+                dispatch(redirectTo('/'));
+            }
         },
         [dispatch]
     );

--- a/packages/frontend/src/utils/storage/session_storage_key.constant.ts
+++ b/packages/frontend/src/utils/storage/session_storage_key.constant.ts
@@ -1,0 +1,3 @@
+export const session_storage_key = {
+    PENDING_DAPP_REDIRECT: 'wallet:pending_dapp_redirect',
+};

--- a/packages/frontend/src/utils/storage/session_storage_key.constant.ts
+++ b/packages/frontend/src/utils/storage/session_storage_key.constant.ts
@@ -1,3 +1,0 @@
-export const session_storage_key = {
-    PENDING_DAPP_REDIRECT: 'wallet:pending_dapp_redirect',
-};

--- a/packages/frontend/src/utils/wallet.ts
+++ b/packages/frontend/src/utils/wallet.ts
@@ -47,6 +47,10 @@ export const WALLET_CREATE_NEW_ACCOUNT_FLOW_URLS = [
     'verify-account',
     'initial-deposit',
     'setup-ledger',
+    'setup-passphrase-new-account',
+    'setup-ledger-new-account',
+    'set-recovery-implicit-account',
+    'create-implicit-account',
 ];
 export const WALLET_LOGIN_URL = 'login';
 export const WALLET_SIGN_URL = 'sign';


### PR DESCRIPTION
Currently, the wallet does not listen to query parameters from dApp actions triggered via near-connect. This change fixes the issue https://github.com/azbang/near-connect/issues/47

Tested:
- new user, click on near-connect and create new wallet on mnw
- new user, click on near-connect and import wallet on mnw
- existing user, do connect dapps