### PR TITLE
fix(send): prevent Send page effect cleanup crash

### DIFF
--- a/packages/frontend/src/components/send/SendContainerV2.js
+++ b/packages/frontend/src/components/send/SendContainerV2.js
@@ -127,7 +127,9 @@ const SendContainerV2 = ({
         }
     }, [getUniqueTokenIdentity(selectedToken)]);
 
-    useEffect(() => window.scrollTo(0, 0), [activeView]);
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [activeView]);
 
     useEffect(() => {
         setActiveView(VIEWS.ENTER_AMOUNT);

--- a/packages/frontend/src/components/send/SendContainerV2.test.js
+++ b/packages/frontend/src/components/send/SendContainerV2.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+
+import SendContainerV2, { VIEWS } from './SendContainerV2';
+
+jest.mock('./components/views/EnterAmount', () => () => null);
+jest.mock('./components/views/EnterReceiver', () => () => null);
+jest.mock('./components/views/Review', () => () => null);
+jest.mock('./components/views/SelectToken', () => () => null);
+jest.mock('./components/views/Success', () => () => null);
+jest.mock('../../mixpanel/index', () => ({ Mixpanel: { track: jest.fn() } }));
+jest.mock('../../services/FungibleTokens', () => ({
+    getFormattedTokenAmount: jest.fn(),
+    getParsedTokenAmount: jest.fn(() => '0'),
+    getUniqueTokenIdentity: (token) => token.contractName,
+}));
+jest.mock('../common/balance/helpers', () => ({ getNearAndFiatValue: jest.fn() }));
+
+const nearToken = {
+    balance: '1000000000000000000000000',
+    contractName: 'NEAR',
+    onChainFTMetadata: { decimals: 24, symbol: 'NEAR' },
+};
+
+const props = {
+    accountId: 'sender.near',
+    accountIdFromUrl: '',
+    activeView: VIEWS.ENTER_AMOUNT,
+    checkAccountAvailable: jest.fn(),
+    clearLocalAlert: jest.fn(),
+    estimatedTotalFees: '0',
+    estimatedTotalInNear: '0',
+    explorerUrl: '',
+    fungibleTokens: [nearToken],
+    handleContinueToReview: jest.fn(),
+    handleSendToken: jest.fn(),
+    isMobile: false,
+    localAlert: null,
+    nearTokenFiatValueUSD: 0,
+    redirectTo: jest.fn(),
+    sendingToken: false,
+    setActiveView: jest.fn(),
+    showNetworkBanner: false,
+    transactionHash: null,
+};
+
+describe('SendContainerV2', () => {
+    let container;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        window.scrollTo = jest.fn(() => ({ not: 'a cleanup function' }));
+    });
+
+    afterEach(() => {
+        act(() => {
+            ReactDOM.unmountComponentAtNode(container);
+        });
+        container.remove();
+    });
+
+    test('does not use the scroll result as an effect cleanup function', () => {
+        act(() => {
+            ReactDOM.render(<SendContainerV2 {...props} />, container);
+        });
+
+        expect(() => {
+            act(() => {
+                ReactDOM.render(
+                    <SendContainerV2 {...props} activeView={VIEWS.SELECT_TOKEN} />,
+                    container
+                );
+            });
+        }).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Issues

Fixes the Send page crash reported on mainnet: `Uncaught TypeError: destroy is not a function`.

## Changes description

- Updated `SendContainerV2`’s scroll effect so it does not implicitly return `window.scrollTo()` as a React effect cleanup value.
- Added a regression test covering view changes when `scrollTo` returns a non-function value.

## Preview

Mainnet local preview: https://localhost:3001/

## Demo

1. Open the wallet and select **Send**.
2. Navigate between Send steps.
3. The Send page remains rendered instead of crashing to a blank page.